### PR TITLE
RimForge 1.6

### DIFF
--- a/1.6/CE_Patches/Patches/CE-Ammo-5×35Caseless.xml
+++ b/1.6/CE_Patches/Patches/CE-Ammo-5×35Caseless.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+      <li Class="PatchOperationAdd">
+        <xpath>Defs</xpath>
+        <value>
+          <ThingCategoryDef>
+            <defName>Ammo5x35mmCaseless</defName>
+            <label>5x35mm Caseless</label>
+            <parent>AmmoRifles</parent>
+            <iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+          </ThingCategoryDef>
+
+          <!-- ==================== AmmoSet ========================== -->
+
+          <CombatExtended.AmmoSetDef>
+            <defName>AmmoSet_5x35mmCaseless</defName>
+            <label>5x35mm Caseless</label>
+            <ammoTypes>
+              <Ammo5x35mmCaseless_FMJ>Bullet_5x35mmCaseless_FMJ</Ammo5x35mmCaseless_FMJ>
+              <Ammo5x35mmCaseless_AP>Bullet_5x35mmCaseless_AP</Ammo5x35mmCaseless_AP>
+              <Ammo5x35mmCaseless_Sabot>Bullet_5x35mmCaseless_Sabot</Ammo5x35mmCaseless_Sabot>
+            </ammoTypes>
+          </CombatExtended.AmmoSetDef>
+
+          <!-- ==================== Ammo ========================== -->
+
+          <ThingDef Class="CombatExtended.AmmoDef" Name="5x35mmCaselessBase" ParentName="SmallAmmoBase" Abstract="True">
+            <description>A small caliber caseless ammunition, with very high velocity and armor-piercing capability but poor stopping power.</description>
+            <statBases>
+              <Mass>0.01</Mass>
+              <Bulk>0.01</Bulk>
+            </statBases>
+            <tradeTags>
+              <li>CE_AutoEnableTrade</li>
+              <li>CE_AutoEnableCrafting</li>
+            </tradeTags>
+            <thingCategories>
+              <li>Ammo5x35mmCaseless</li>
+            </thingCategories>
+          </ThingDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="5x35mmCaselessBase">
+            <defName>Ammo5x35mmCaseless_FMJ</defName>
+            <label>5x35mm Caseless (FMJ)</label>
+            <graphicData>
+              <texPath>Things/Ammo/Rifle/FMJ</texPath>
+              <graphicClass>Graphic_StackCount</graphicClass>
+            </graphicData>
+            <statBases>
+              <MarketValue>0.065</MarketValue>
+            </statBases>
+            <ammoClass>FullMetalJacket</ammoClass>
+            <cookOffProjectile>Bullet_5x35mmCaseless_FMJ</cookOffProjectile>
+          </ThingDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="5x35mmCaselessBase">
+            <defName>Ammo5x35mmCaseless_AP</defName>
+            <label>5x35mm Caseless (AP)</label>
+            <graphicData>
+              <texPath>Things/Ammo/Rifle/AP</texPath>
+              <graphicClass>Graphic_StackCount</graphicClass>
+            </graphicData>
+            <statBases>
+              <MarketValue>0.065</MarketValue>
+            </statBases>
+            <ammoClass>ArmorPiercing</ammoClass>
+            <cookOffProjectile>Bullet_5x35mmCaseless_AP</cookOffProjectile>
+          </ThingDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="5x35mmCaselessBase">
+            <defName>Ammo5x35mmCaseless_Sabot</defName>
+            <label>5x35mm Caseless (Sabot)</label>
+            <graphicData>
+              <texPath>Things/Ammo/Rifle/Sabot</texPath>
+              <graphicClass>Graphic_StackCount</graphicClass>
+            </graphicData>
+            <statBases>
+              <MarketValue>0.075</MarketValue>
+              <Mass>0.01</Mass>
+            </statBases>
+            <ammoClass>Sabot</ammoClass>
+            <cookOffProjectile>Bullet_5x35mmCaseless_Sabot</cookOffProjectile>
+          </ThingDef>
+
+          <!-- ================== Projectiles ================== -->
+
+          <ThingDef Class="CombatExtended.AmmoDef" Name="5x35mmCaselessBaseBullet" ParentName="Base556x45mmNATOBullet" Abstract="true">
+            <graphicData>
+              <texPath>Things/Projectile/Bullet_Small</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageDef>Bullet</damageDef>
+              <speed>220</speed>
+              <dropsCasings>false</dropsCasings>
+            </projectile>
+            <tradeTags>
+              <li>CE_AutoEnableTrade</li>
+              <li>CE_AutoEnableCrafting</li>
+            </tradeTags>
+            <thingCategories>
+              <li>Ammo5x35mmCaseless</li>
+            </thingCategories>
+          </ThingDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="5x35mmCaselessBaseBullet">
+            <defName>Bullet_5x35mmCaseless_FMJ</defName>
+            <label>5x35 caseless bullet (FMJ)</label>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageAmountBase>10</damageAmountBase>
+              <armorPenetrationSharp>12</armorPenetrationSharp>
+              <armorPenetrationBlunt>36</armorPenetrationBlunt>
+            </projectile>
+          </ThingDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="5x35mmCaselessBaseBullet">
+            <defName>Bullet_5x35mmCaseless_AP</defName>
+            <label>5x35 caseless bullet (AP)</label>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageAmountBase>8</damageAmountBase>
+              <armorPenetrationSharp>20</armorPenetrationSharp>
+              <armorPenetrationBlunt>37</armorPenetrationBlunt>
+            </projectile>
+          </ThingDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="5x35mmCaselessBaseBullet">
+            <defName>Bullet_5x35mmCaseless_Sabot</defName>
+            <label>5x35 caseless bullet (Sabot)</label>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageAmountBase>7</damageAmountBase>
+              <armorPenetrationSharp>35</armorPenetrationSharp>
+              <armorPenetrationBlunt>50</armorPenetrationBlunt>
+              <speed>290</speed>
+            </projectile>
+          </ThingDef>
+
+          <!-- ==================== Recipes ========================== -->
+
+          <RecipeDef ParentName="AmmoRecipeBase">
+            <defName>MakeAmmo5x35mmCaseless_FMJ</defName>
+            <label>make 5x35mm caseless (FMJ) cartridge x500</label>
+            <description>Craft 500 5x35mm caseless (FMJ) cartridges.</description>
+            <jobString>Making 5x35mm caseless (FMJ) cartridges.</jobString>
+            <ingredients>
+              <li>
+                <filter>
+                  <thingDefs>
+                    <li>RF_Copper</li>
+                  </thingDefs>
+                </filter>
+                <count>10</count>
+              </li>
+            </ingredients>
+            <fixedIngredientFilter>
+              <thingDefs>
+                <li>RF_Copper</li>
+              </thingDefs>
+            </fixedIngredientFilter>
+            <products>
+              <Ammo5x35mmCaseless_FMJ>500</Ammo5x35mmCaseless_FMJ>
+            </products>
+            <workAmount>1600</workAmount>
+          </RecipeDef>
+
+          <RecipeDef ParentName="AmmoRecipeBase">
+            <defName>MakeAmmo5x35mmCaseless_AP</defName>
+            <label>make 5x35mm caseless (AP) cartridge x500</label>
+            <description>Craft 500 5x35mm caseless (AP) cartridges.</description>
+            <jobString>Making 5x35mm caseless (AP) cartridges.</jobString>
+            <ingredients>
+              <li>
+                <filter>
+                  <thingDefs>
+                    <li>RF_Bronze</li>
+                  </thingDefs>
+                </filter>
+                <count>12</count>
+              </li>
+            </ingredients>
+            <fixedIngredientFilter>
+              <thingDefs>
+                <li>RF_Bronze</li>
+              </thingDefs>
+            </fixedIngredientFilter>
+            <products>
+              <Ammo5x35mmCaseless_AP>500</Ammo5x35mmCaseless_AP>
+            </products>
+            <workAmount>1700</workAmount>
+          </RecipeDef>
+
+          <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+            <defName>MakeAmmo5x35mmCaseless_Sabot</defName>
+            <label>make 5x35mm caseless (Sabot) cartridge x500</label>
+            <description>Craft 500 5x35mm caseless (Sabot) cartridges.</description>
+            <jobString>Making 5x35mm caseless (Sabot) cartridges.</jobString>
+            <ingredients>
+              <li>
+                <filter>
+                  <thingDefs>
+                    <li>RF_Staballoy</li>
+                  </thingDefs>
+                </filter>
+                <count>10</count>
+              </li>
+              <li>
+                <filter>
+                  <thingDefs>
+                    <li>Chemfuel</li>
+                  </thingDefs>
+                </filter>
+                <count>2</count>
+              </li>
+            </ingredients>
+            <fixedIngredientFilter>
+              <thingDefs>
+                <li>RF_Staballoy</li>
+                <li>Chemfuel</li>
+              </thingDefs>
+            </fixedIngredientFilter>
+            <products>
+              <Ammo5x35mmCaseless_Sabot>500</Ammo5x35mmCaseless_Sabot>
+            </products>
+            <workAmount>2200</workAmount>
+          </RecipeDef>
+
+        </value>
+      </li>
+    </operations>
+  </Operation>
+  
+</Patch>

--- a/1.6/CE_Patches/Patches/CE-Melee-CursedKhopesh.xml
+++ b/1.6/CE_Patches/Patches/CE-Melee-CursedKhopesh.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+
+      <!-- === RF_CursedKhopesh === -->
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="RF_CursedKhopesh"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>blade</label>
+              <capacities>
+                <li>Cut</li>
+              </capacities>
+              <power>25</power>
+              <cooldownTime>1.2</cooldownTime>
+              <armorPenetrationBlunt>14</armorPenetrationBlunt>
+              <armorPenetrationSharp>16</armorPenetrationSharp>
+              <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>          
+            </li>
+          </tools>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="RF_CursedKhopesh"]/statBases</xpath>
+        <value>
+          <Bulk>10</Bulk>
+          <MeleeCounterParryBonus>0.8</MeleeCounterParryBonus>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="RF_CursedKhopesh"]/equippedStatOffsets</xpath>
+        <value>
+          <MeleeCritChance>0.3</MeleeCritChance>
+          <MeleeParryChance>0.5</MeleeParryChance>
+          <MeleeDodgeChance>0.3</MeleeDodgeChance>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+  
+</Patch>

--- a/1.6/CE_Patches/Patches/CE-Melee-GaeBulg.xml
+++ b/1.6/CE_Patches/Patches/CE-Melee-GaeBulg.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+
+      <!-- === RF_GaeBulg === -->
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="RF_GaeBulg"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>point</label>
+              <capacities>
+                <li>Stab</li>
+              </capacities>
+              <power>22</power>
+              <cooldownTime>0.75</cooldownTime>
+              <armorPenetrationBlunt>10</armorPenetrationBlunt>
+              <armorPenetrationSharp>18</armorPenetrationSharp>
+              <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+            </li>
+          </tools>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="RF_GaeBulg"]/statBases</xpath>
+        <value>
+          <Bulk>15</Bulk>
+          <MeleeCounterParryBonus>0.8</MeleeCounterParryBonus>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="RF_GaeBulg"]/equippedStatOffsets</xpath>
+        <value>
+          <MeleeCritChance>0.4</MeleeCritChance>
+          <MeleeParryChance>1.0</MeleeParryChance>
+          <MeleeDodgeChance>0.4</MeleeDodgeChance>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+  
+</Patch>

--- a/1.6/CE_Patches/Patches/CE-Melee-Khopesh.xml
+++ b/1.6/CE_Patches/Patches/CE-Melee-Khopesh.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+
+      <!-- === RF_Khopesh === -->
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="RF_Khopesh"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>blade</label>
+              <capacities>
+                <li>Cut</li>
+              </capacities>
+              <power>20</power>
+              <cooldownTime>1.2</cooldownTime>
+              <armorPenetrationBlunt>12</armorPenetrationBlunt>
+              <armorPenetrationSharp>14</armorPenetrationSharp>
+              <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>          
+            </li>
+          </tools>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="RF_Khopesh"]/statBases</xpath>
+        <value>
+          <Bulk>10</Bulk>
+          <MeleeCounterParryBonus>0.8</MeleeCounterParryBonus>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="RF_Khopesh"]/equippedStatOffsets</xpath>
+        <value>
+          <MeleeCritChance>0.3</MeleeCritChance>
+          <MeleeParryChance>0.5</MeleeParryChance>
+          <MeleeDodgeChance>0.3</MeleeDodgeChance>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+  
+</Patch>

--- a/1.6/CE_Patches/Patches/CE-Melee-SwordOfDarkness.xml
+++ b/1.6/CE_Patches/Patches/CE-Melee-SwordOfDarkness.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+
+      <!-- === RF_SwordOfDarkness === -->
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="RF_SwordOfDarkness"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>blade</label>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>50</power>
+              <cooldownTime>1.1</cooldownTime>
+              <armorPenetrationBlunt>50</armorPenetrationBlunt>
+              <armorPenetrationSharp>5</armorPenetrationSharp>
+              <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+            </li>
+          </tools>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="RF_SwordOfDarkness"]/statBases</xpath>
+        <value>
+          <Bulk>17</Bulk>
+          <MeleeCounterParryBonus>1.2</MeleeCounterParryBonus>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="RF_SwordOfDarkness"]/equippedStatOffsets</xpath>
+        <value>
+          <MeleeCritChance>0.5</MeleeCritChance>
+          <MeleeParryChance>1.1</MeleeParryChance>
+          <MeleeDodgeChance>0.5</MeleeDodgeChance>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+  
+</Patch>

--- a/1.6/CE_Patches/Patches/CE-Melee-SwordOfRapture.xml
+++ b/1.6/CE_Patches/Patches/CE-Melee-SwordOfRapture.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+
+      <!-- === RF_SwordOfRapture === -->
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="RF_SwordOfRapture"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>blade</label>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>45</power>
+              <cooldownTime>0.9</cooldownTime>
+              <armorPenetrationBlunt>35</armorPenetrationBlunt>
+              <armorPenetrationSharp>5</armorPenetrationSharp>
+              <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+            </li>
+          </tools>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="RF_SwordOfRapture"]/statBases</xpath>
+        <value>
+          <Bulk>17</Bulk>
+          <MeleeCounterParryBonus>1.3</MeleeCounterParryBonus>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="RF_SwordOfRapture"]/equippedStatOffsets</xpath>
+        <value>
+          <MeleeCritChance>0.5</MeleeCritChance>
+          <MeleeParryChance>1.1</MeleeParryChance>
+          <MeleeDodgeChance>0.5</MeleeDodgeChance>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+  
+</Patch>

--- a/1.6/CE_Patches/Patches/CE-Melee-VirtuousTreaty.xml
+++ b/1.6/CE_Patches/Patches/CE-Melee-VirtuousTreaty.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+
+      <!-- === RF_VirtuousTreaty === -->
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="RF_VirtuousTreaty"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>point</label>
+              <capacities>
+                <li>Stab</li>
+              </capacities>
+              <power>25</power>
+              <cooldownTime>1.5</cooldownTime>
+              <chanceFactor>0.10</chanceFactor>
+              <armorPenetrationBlunt>20</armorPenetrationBlunt>
+              <armorPenetrationSharp>25</armorPenetrationSharp>
+              <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>edge</label>
+              <capacities>
+                <li>Cut</li>
+              </capacities>
+              <power>30</power>
+              <cooldownTime>2</cooldownTime>
+              <chanceFactor>0.50</chanceFactor>
+              <armorPenetrationBlunt>13</armorPenetrationBlunt>
+              <armorPenetrationSharp>18</armorPenetrationSharp>
+              <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+            </li>
+          </tools>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="RF_VirtuousTreaty"]/statBases</xpath>
+        <value>
+          <Bulk>20</Bulk>
+          <MeleeCounterParryBonus>1.1</MeleeCounterParryBonus>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="RF_VirtuousTreaty"]/equippedStatOffsets</xpath>
+        <value>
+          <MeleeCritChance>0.8</MeleeCritChance>
+          <MeleeParryChance>0.9</MeleeParryChance>
+          <MeleeDodgeChance>0.55</MeleeDodgeChance>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+
+</Patch>

--- a/1.6/CE_Patches/Patches/CE-Ranged-StablePistol.xml
+++ b/1.6/CE_Patches/Patches/CE-Ranged-StablePistol.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+
+      <!-- === RF_StablePistol === -->
+      <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+        <defName>RF_StablePistol</defName>
+        <statBases>
+          <Mass>2.0</Mass>
+          <RangedWeapon_Cooldown>0.2</RangedWeapon_Cooldown>
+          <SightsEfficiency>1.25</SightsEfficiency>
+          <ShotSpread>0.02</ShotSpread>
+          <SwayFactor>0.5</SwayFactor>
+          <Bulk>4.5</Bulk>
+        </statBases>
+        <Properties>
+          <recoilAmount>0.05</recoilAmount>
+          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+          <hasStandardCommand>true</hasStandardCommand>
+          <defaultProjectile>Bullet_5x35mmCaseless_FMJ</defaultProjectile>
+          <burstShotCount>1</burstShotCount>
+          <warmupTime>0.25</warmupTime>
+          <range>40</range>
+          <soundCast>RF_Sound_StableRifleShot</soundCast>
+          <soundCastTail>GunTail_Medium</soundCastTail>
+          <muzzleFlashScale>9</muzzleFlashScale>
+        </Properties>
+        <AmmoUser>
+          <magazineSize>16</magazineSize>
+          <reloadTime>1.5</reloadTime>
+          <ammoSet>AmmoSet_5x35mmCaseless</ammoSet>
+        </AmmoUser>
+        <FireModes>
+          <aimedBurstShotCount>1</aimedBurstShotCount>
+          <aiUseBurstMode>false</aiUseBurstMode>
+          <aiAimMode>AimedShot</aiAimMode>
+        </FireModes>
+        <weaponTags>
+          <li>CE_AI_Pistol</li>
+        </weaponTags>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName="RF_StablePistol"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>stock</label>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>5</power>
+              <cooldownTime>1.55</cooldownTime>
+              <chanceFactor>1.5</chanceFactor>
+              <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+              <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>barrel</label>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>4</power>
+              <cooldownTime>2.02</cooldownTime>
+              <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+              <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>muzzle</label>
+              <capacities>
+                <li>Poke</li>
+              </capacities>
+              <power>5</power>
+              <cooldownTime>1.55</cooldownTime>
+              <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+              <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+            </li>
+          </tools>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+  
+</Patch>

--- a/1.6/CE_Patches/Patches/CE-Ranged-StableRifle.xml
+++ b/1.6/CE_Patches/Patches/CE-Ranged-StableRifle.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+
+      <!-- === RF_StableRifle === -->
+      <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+        <defName>RF_StableRifle</defName>
+        <statBases>
+          <Mass>3.5</Mass>
+          <RangedWeapon_Cooldown>0.30</RangedWeapon_Cooldown>
+          <SightsEfficiency>1.3</SightsEfficiency>
+          <ShotSpread>0.04</ShotSpread>
+          <SwayFactor>0.85</SwayFactor>
+          <Bulk>7.5</Bulk>
+        </statBases>
+        <Properties>
+          <recoilAmount>0.1</recoilAmount>
+          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+          <hasStandardCommand>true</hasStandardCommand>
+          <defaultProjectile>Bullet_5x35mmCaseless_FMJ</defaultProjectile>
+          <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+          <burstShotCount>5</burstShotCount>
+          <warmupTime>0.85</warmupTime>
+          <range>65</range>
+          <soundCast>RF_Sound_StableRifleShot</soundCast>
+          <soundCastTail>GunTail_Medium</soundCastTail>
+          <muzzleFlashScale>9</muzzleFlashScale>
+        </Properties>
+        <AmmoUser>
+          <magazineSize>30</magazineSize>
+          <reloadTime>3</reloadTime>
+          <ammoSet>AmmoSet_5x35mmCaseless</ammoSet>
+        </AmmoUser>
+        <FireModes>
+          <aimedBurstShotCount>3</aimedBurstShotCount>
+          <aiUseBurstMode>TRUE</aiUseBurstMode>
+          <aiAimMode>AimedShot</aiAimMode>
+        </FireModes>
+        <weaponTags>
+          <li>CE_AI_Rifle</li>
+        </weaponTags>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName="RF_StableRifle"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>stock</label>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>8</power>
+              <cooldownTime>1.55</cooldownTime>
+              <chanceFactor>1.5</chanceFactor>
+              <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+              <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>barrel</label>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>5</power>
+              <cooldownTime>2.02</cooldownTime>
+              <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+              <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>muzzle</label>
+              <capacities>
+                <li>Poke</li>
+              </capacities>
+              <power>8</power>
+              <cooldownTime>1.55</cooldownTime>
+              <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+              <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+            </li>
+          </tools>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+  
+</Patch>

--- a/1.6/CE_Patches/Patches/CE-StuffableFix.xml
+++ b/1.6/CE_Patches/Patches/CE-StuffableFix.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <!-- Combat extended makes it so stuffable melee weapons can only be made out of
+       'Metallic_Weapon' stuff, which doesn't include bronze and other alloys.
+        So, add these alloys to the allowed list.-->
+
+  <!-- By default, allows the following to be used as weapon metals: 
+    * Bronze
+    * Adamantium
+    * Staballoy -->
+
+  <Operation Class="PatchOperationSequence">
+    <operations>
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="RF_Bronze" or
+                                defName="RF_Adamantium" or
+                                defName="RF_Staballoy"]/stuffProps/categories</xpath>
+        <value>
+          <li>Metallic_Weapon</li>
+          <li>RF_WeaponAlloy</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="RF_VirtuousTreaty"]/stuffCategories</xpath>
+        <value>
+          <stuffCategories>
+            <li>RF_WeaponAlloy</li>
+          </stuffCategories>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+  
+</Patch>

--- a/1.6/Defs/Alloy Recipes/RimForge Alloys.xml
+++ b/1.6/Defs/Alloy Recipes/RimForge Alloys.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <!-- MISC CATEGORY DEFS -->
+
+  <StatCategoryDef>
+    <defName>RF_RimForgeStats</defName>
+    <label>RimForge</label>
+    <displayOrder>110</displayOrder>
+    <displayAllByDefault>true</displayAllByDefault>
+  </StatCategoryDef>
+
+  <StuffCategoryDef>
+    <defName>RF_WeaponAlloy</defName>
+    <label>weapon-grade alloy</label>
+    <destroySoundSmall>BuildingDestroyed_Metal_Small</destroySoundSmall>
+    <destroySoundMedium>BuildingDestroyed_Metal_Medium</destroySoundMedium>
+    <destroySoundLarge>BuildingDestroyed_Metal_Big</destroySoundLarge>
+  </StuffCategoryDef>
+
+  <StuffCategoryDef>
+    <defName>RF_PowerPoleMetals</defName>
+    <label>power pole cable material</label>
+    <destroySoundSmall>BuildingDestroyed_Metal_Small</destroySoundSmall>
+    <destroySoundMedium>BuildingDestroyed_Metal_Medium</destroySoundMedium>
+    <destroySoundLarge>BuildingDestroyed_Metal_Big</destroySoundLarge>
+  </StuffCategoryDef>
+
+  <!-- Alloys -->
+
+  <RimForge.AlloyDef>
+    <defName>RF_BronzeAlloy</defName>
+    <label>make bronze</label>
+    <description>Make bronze, an alloy of copper and tin, that has been in use since ancient times.
+Makes for very good tools, weapons and armor, at the cost of beauty and construction time.</description>
+    
+    <input>
+      <li>
+        <resource>RF_Copper</resource>
+        <count>9</count>
+      </li>
+      <li>
+        <resource>RF_Tin</resource>
+        <count>1</count>
+      </li>
+    </input>
+
+    <output>
+      <resource>RF_Bronze</resource>
+      <count>10</count>
+    </output>
+  </RimForge.AlloyDef>
+
+  <RimForge.AlloyDef>
+    <defName>RF_Adamantium</defName>
+    <label>make adamantium</label>
+    <description>Make adamantium, a complex alloy of Bronze, Staballoy and Gilded Plasteel.
+It is unbelievably strong, and can be sharpened to a razor's edge without risk of it fracturing.
+It's dark surface is strangely beautiful.</description>
+    
+    <input>
+      <li>
+        <resource>RF_Bronze</resource>
+        <count>2</count>
+      </li>
+      <li>
+        <resource>RF_Staballoy</resource>
+        <count>3</count>
+      </li>
+      <li>
+        <resource>RF_GildedPlasteel</resource>
+        <count>3</count>
+      </li>
+    </input>
+
+    <output>
+      <resource>RF_Adamantium</resource>
+      <count>3</count>
+    </output>
+  </RimForge.AlloyDef>
+
+</Defs>

--- a/1.6/Defs/Alloy Recipes/VanillaAlloys.xml
+++ b/1.6/Defs/Alloy Recipes/VanillaAlloys.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <RimForge.AlloyDef>
+    <defName>RF_GoldDoreAlloy</defName>
+    <label>make gold doré</label>
+    <description>Make gold doré, a semi-pure alloy of gold and silver. Not very useful as a material due to it's softness, but exceedingly beautiful.</description>
+    
+    <input>
+      <li>
+        <resource>Gold</resource>
+        <count>7</count>
+      </li>
+      <li>
+        <resource>Silver</resource>
+        <count>3</count>
+      </li>
+    </input>
+
+    <output>
+      <resource>RF_GoldDore</resource>
+      <count>8</count>
+    </output>
+  </RimForge.AlloyDef>
+
+  <RimForge.AlloyDef>
+    <defName>RF_GildedPlasteel</defName>
+    <label>make gilded plasteel</label>
+    <description>Make gilded plasteel, an alloy of plasteel and gold.
+Retains the toughness of plasteel but becomes more malleable, leading to faster construction times. It's also very pretty to look at.</description>
+  
+    <input>
+      <li>
+        <resource>Plasteel</resource>
+        <count>2</count>
+      </li>
+      <li>
+        <resource>Gold</resource>
+        <count>1</count>
+      </li>
+    </input>
+
+    <output>
+      <resource>RF_GildedPlasteel</resource>
+      <count>2</count>
+    </output>
+  </RimForge.AlloyDef>
+
+  <RimForge.AlloyDef>
+    <defName>RF_StaballoyAlloy</defName>
+    <label>make staballoy</label>
+    <description>Incredibly dense and resitant to blunt and sharp damage, but very ugly to look at.
+It's strength allows to to be forged into wickedly sharp bladed weapons, but the wielder may find the weight overwhelming.</description>
+  
+    <input>
+      <li>
+        <resource>Uranium</resource>
+        <count>9</count>
+      </li>
+      <li>
+        <resource>Plasteel</resource>
+        <count>1</count>
+      </li>
+    </input>
+
+    <output>
+      <resource>RF_Staballoy</resource>
+      <count>10</count>
+    </output>
+  </RimForge.AlloyDef>
+
+</Defs>

--- a/1.6/Defs/AlloyCategory.xml
+++ b/1.6/Defs/AlloyCategory.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <ThingCategoryDef>
+    <defName>Alloys</defName>
+    <label>alloys</label>
+    <parent>Root</parent>
+    <resourceReadoutRoot>true</resourceReadoutRoot>
+    <iconPath>RF/Resources/Copper</iconPath>
+  </ThingCategoryDef>
+</Defs>

--- a/1.6/Defs/Buildings/Capacitor.xml
+++ b/1.6/Defs/Buildings/Capacitor.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef Name="RF_CapacitorBase" ParentName="BuildingBase" Abstract="True">
+    <thingClass>RimForge.Buildings.Building_Capacitor</thingClass>
+    <graphicData>
+      <texPath>RF/Buildings/Capacitor</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1,2)</drawSize>
+      <drawOffset>(0, 0, 0.5)</drawOffset>
+    </graphicData>
+    <passability>PassThroughOnly</passability>
+    <designationCategory>Power</designationCategory>
+    <drawerType>RealtimeOnly</drawerType>
+    <selectable>true</selectable>
+    <canOverlapZones>true</canOverlapZones>
+    <castEdgeShadows>false</castEdgeShadows>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <tickerType>Normal</tickerType>
+    <category>Building</category>
+    <altitudeLayer>BuildingOnTop</altitudeLayer>
+    <pathCost>20</pathCost>
+    <size>(1, 1)</size>
+    <costList>
+      <Steel>20</Steel>
+      <ComponentSpacer>4</ComponentSpacer>
+      <RF_Copper>50</RF_Copper>
+    </costList>
+    <statBases>
+      <MaxHitPoints>100</MaxHitPoints>
+      <WorkToBuild>5000</WorkToBuild>
+      <Flammability>0.25</Flammability>
+      <Beauty>-2</Beauty>
+      <Cleanliness>2</Cleanliness>
+      <Mass>30</Mass>
+    </statBases>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <thingCategories>
+      <li>BuildingsPower</li>
+    </thingCategories>
+    <constructionSkillPrerequisite>5</constructionSkillPrerequisite>
+    <comps>
+      <li Class="RimForge.Comps.CompProperties_Capacitor">
+        <powerRequirement>2000</powerRequirement>
+        <ticksToCharge>2500</ticksToCharge>
+      </li>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <transmitsPower>false</transmitsPower>
+        <basePowerConsumption>2000</basePowerConsumption>
+        <shortCircuitInRain>false</shortCircuitInRain>
+      </li>
+    </comps>
+    <researchPrerequisites>
+      <li>RF_Research_Coilgun</li>
+    </researchPrerequisites>
+    <descriptionHyperlinks>
+      <ThingDef>RF_Coilgun</ThingDef>
+    </descriptionHyperlinks>
+  </ThingDef>
+
+  <!-- Normal version -->
+  <ThingDef ParentName="RF_CapacitorBase">
+    <defName>RF_Capacitor</defName>
+    <label>coilgun capacitor</label>
+    <description>An electrical capacitor that is required to fire a Liandry Coilgun.
+Charges up over time.
+Note: Will not output electricity like a normal battery.</description>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Buildings/Coilgun.xml
+++ b/1.6/Defs/Buildings/Coilgun.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <RimForge.CoilgunDef ParentName="BuildingBase">
+    <defName>RF_Coilgun</defName>
+    <thingClass>RimForge.Buildings.Building_Coilgun</thingClass>
+    <label>liandry coilgun</label>
+    <description>A coilgun, also called a gauss rifle, accelerates a kinetic projectile using an electrical current similarly to the way a railgun works.
+This particular coilgun is a huge mounted cannon, firing a 4kg staballoy armor piercing slug at over 5000 m/s, capable of literally firing through a mountain.
+
+When fired, it's projectile will pass through everything and anything along it's path, including normally un-penetrable surfaces such as walls or even mountains.
+However, damage is reduced after passing through solid objects.
+
+Requires Coilgun Capacitors to be connected to the same power grid in order to fire.</description>
+    <uiIconPath>RF/Buildings/Coilgun/Icon</uiIconPath>
+    <descriptionHyperlinks>
+      <ThingDef>RF_Capacitor</ThingDef>
+    </descriptionHyperlinks>
+    <graphicData>
+      <texPath>RF/Buildings/Coilgun/Base</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(5, 5)</drawSize>
+    </graphicData>
+    <drawOffscreen>true</drawOffscreen>
+    <drawerType>RealtimeOnly</drawerType>
+    <altitudeLayer>BuildingOnTop</altitudeLayer>
+    <stealable>false</stealable>
+    <rotatable>false</rotatable>
+    <size>(5,5)</size>
+    <statBases>
+      <MaxHitPoints>1400</MaxHitPoints>
+      <Flammability>0.5</Flammability>
+      <WorkToBuild>15000</WorkToBuild>
+      <Mass>400</Mass>
+      <Beauty>-25</Beauty>
+    </statBases>
+    <costList>
+      <Steel>300</Steel>
+      <RF_Copper>150</RF_Copper>
+      <ComponentSpacer>5</ComponentSpacer>
+      <RF_Staballoy>50</RF_Staballoy>
+    </costList>
+    <tickerType>Normal</tickerType>
+    <passability>PassThroughOnly</passability>
+    <pathCost>150</pathCost>
+    <fillPercent>0.8</fillPercent>
+    <hasTooltip>true</hasTooltip>
+    <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
+    <designationCategory>Security</designationCategory>
+    <constructionSkillPrerequisite>14</constructionSkillPrerequisite>
+    <building>
+      <ai_combatDangerous>true</ai_combatDangerous>
+    </building>
+    <researchPrerequisites>
+      <li>RF_Research_Coilgun</li>
+    </researchPrerequisites>
+    <designationHotKey>Misc3</designationHotKey>
+    <uiIconScale>1</uiIconScale>
+    <comps>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <transmitsPower>false</transmitsPower>
+        <shortCircuitInRain>false</shortCircuitInRain>
+        <basePowerConsumption>500</basePowerConsumption>
+      </li>
+      <li Class="CompProperties_Refuelable">
+        <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
+        <fuelConsumptionRate>0.0</fuelConsumptionRate>
+        <fuelCapacity>1</fuelCapacity>
+        <fuelFilter>
+          <thingDefs>
+          </thingDefs>
+        </fuelFilter>
+        <autoRefuelPercent>0.1</autoRefuelPercent>
+        <showFuelGizmo>true</showFuelGizmo>
+        <drawOutOfFuelOverlay>false</drawOutOfFuelOverlay>
+        <drawFuelGaugeInMap>false</drawFuelGaugeInMap>
+        <showAllowAutoRefuelToggle>false</showAllowAutoRefuelToggle>
+      </li>
+    </comps>
+  </RimForge.CoilgunDef>
+
+</Defs>

--- a/1.6/Defs/Buildings/DroneLauncher.xml
+++ b/1.6/Defs/Buildings/DroneLauncher.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BuildingBase">
+    <defName>RF_DroneLauncher</defName>
+    <label>strike drone launcher</label>
+    <description>A station for deploying an unmanned air-strike drone.
+The drone can be sent to carpet bomb invading raiders.</description>
+    <thingClass>RimForge.Buildings.Building_DroneLauncher</thingClass>
+    <graphicData>
+      <texPath>RF/Buildings/DroneLauncher</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <drawSize>(5,5)</drawSize>
+    </graphicData>
+    <passability>Impassable</passability>
+    <designationCategory>Security</designationCategory>
+    <drawerType>RealtimeOnly</drawerType>
+    <selectable>true</selectable>
+    <fillPercent>1</fillPercent>
+    <coversFloor>true</coversFloor>
+    <holdsRoof>false</holdsRoof>
+    <blockLight>false</blockLight>
+    <canOverlapZones>false</canOverlapZones>
+    <castEdgeShadows>true</castEdgeShadows>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <tickerType>Normal</tickerType>
+    <drawOffscreen>true</drawOffscreen>
+    <category>Building</category>
+    <altitudeLayer>BuildingOnTop</altitudeLayer>
+    <size>(2, 3)</size>
+    <rotatable>true</rotatable>
+    <defaultPlacingRot>East</defaultPlacingRot>
+    <costList>
+      <RF_GildedPlasteel>100</RF_GildedPlasteel>
+      <RF_Copper>50</RF_Copper>
+      <ComponentSpacer>4</ComponentSpacer>
+    </costList>
+    <comps>
+      <li Class="CompProperties_Refuelable">
+        <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
+        <fuelConsumptionRate>0.0</fuelConsumptionRate>
+        <fuelCapacity>6</fuelCapacity>
+        <fuelFilter>
+          <thingDefs>
+          </thingDefs>
+        </fuelFilter>
+        <autoRefuelPercent>1</autoRefuelPercent>
+        <showFuelGizmo>true</showFuelGizmo>
+        <drawOutOfFuelOverlay>false</drawOutOfFuelOverlay>
+        <drawFuelGaugeInMap>false</drawFuelGaugeInMap>
+        <showAllowAutoRefuelToggle>true</showAllowAutoRefuelToggle>
+        <targetFuelLevelConfigurable>true</targetFuelLevelConfigurable>
+        <initialConfigurableTargetFuelLevel>6</initialConfigurableTargetFuelLevel>
+      </li>
+      <li Class="CompProperties_Flickable"></li>
+    </comps>
+    <researchPrerequisites>
+      <li>RF_Research_StrikeDrone</li>
+    </researchPrerequisites>
+    <statBases>
+      <MaxHitPoints>500</MaxHitPoints>
+      <WorkToBuild>8000</WorkToBuild>
+      <Flammability>0.25</Flammability>
+      <Beauty>-2</Beauty>
+      <Cleanliness>1</Cleanliness>
+      <Mass>100</Mass>
+    </statBases>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <thingCategories>
+      <li>BuildingsMisc</li>
+    </thingCategories>
+    <constructionSkillPrerequisite>14</constructionSkillPrerequisite>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Buildings/Forge.xml
+++ b/1.6/Defs/Buildings/Forge.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef Name="RF_BuildingBase" ParentName="BuildingBase" Abstract="True">
+    <category>Building</category>
+    <tickerType>Normal</tickerType>
+    <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
+    <canOverlapZones>false</canOverlapZones>
+    <designationCategory>Production</designationCategory>
+    <altitudeLayer>Building</altitudeLayer>
+    <passability>PassThroughOnly</passability>
+    <blockWind>true</blockWind>
+    <castEdgeShadows>true</castEdgeShadows>
+    <pathCost>90</pathCost>
+    <size>(3,3)</size>
+    <leaveResourcesWhenKilled>true</leaveResourcesWhenKilled>
+    <rotatable>true</rotatable>
+    <statBases>
+      <MaxHitPoints>400</MaxHitPoints>
+      <WorkToBuild>30000</WorkToBuild>
+      <Flammability>0.25</Flammability>
+      <Beauty>-2</Beauty>
+      <Cleanliness>-2</Cleanliness>
+      <Mass>80</Mass>
+    </statBases>
+    <building>
+      <ai_chillDestination>false</ai_chillDestination>
+    </building>
+    <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
+  </ThingDef>
+
+  <ThingDef ParentName="RF_BuildingBase">
+    <defName>RF_Forge</defName>
+    <thingClass>RimForge.Buildings.Building_ForgeRewritten</thingClass>
+    <label>forge</label>
+    <description>A metal-smelting forge. Melts down metals, to create alloys out of them.
+Requires at least 1 heating element to be built directly adjacent (left or right) to it in order to generate heat and create alloys.</description>
+    <graphicData>
+      <texPath>RF/Buildings/ForgeIdle</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(3,3)</drawSize>
+      <drawOffset>(0,0,0.5)</drawOffset>
+    </graphicData>
+    <rotatable>false</rotatable>
+    <drawerType>RealtimeOnly</drawerType>
+    <altitudeLayer>LayingPawn</altitudeLayer>
+    <selectable>true</selectable>
+    <size>(3, 2)</size>
+    <hasInteractionCell>true</hasInteractionCell>
+    <interactionCellOffset>(0,0,-1)</interactionCellOffset>
+    <costList>
+      <Steel>350</Steel>
+      <ComponentIndustrial>8</ComponentIndustrial>
+    </costList>   
+    <researchPrerequisites>
+      <li>RF_Research_Forge</li>
+    </researchPrerequisites> 
+    <inspectorTabs>
+      <li>ITab_Bills</li>
+     </inspectorTabs>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <thingCategories>
+      <li>BuildingsProduction</li>
+    </thingCategories>
+    <comps>
+      <li Class="CompProperties_Glower">
+        <!-- A Harmony patch ensures that this only glows when required. -->
+        <glowRadius>6</glowRadius>
+        <glowColor>(255,248,214,255)</glowColor>
+      </li>
+    </comps>
+    <constructionSkillPrerequisite>10</constructionSkillPrerequisite>
+    <placeWorkers>
+      <li>PlaceWorker_PreventInteractionSpotOverlap</li>
+      <li>PlaceWorker_Heater</li>
+    </placeWorkers>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Buildings/GreenhouseController.xml
+++ b/1.6/Defs/Buildings/GreenhouseController.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BuildingBase">
+    <defName>RF_GreenhouseController</defName>
+    <label>greenhouse controller</label>
+    <description>When placed in a greenhouse, consumes vast amounts of electricity to control air gas composition.
+Plants growing within the greenhouse will grow at 2x the regular speed during the day, and will keep growing at 1x speed during the night.
+    
+Any enclosed room (up to a maximum size) is considered to be a greenhouse.
+Note: for performance reasons, the plant's growth rate stat does not appear to change, but they will be growing faster.</description>
+    <thingClass>RimForge.Buildings.Building_GreenhouseController</thingClass>
+    <graphicData>
+      <texPath>RF/Buildings/Greenhouse/Idle</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1,1)</drawSize>
+    </graphicData>
+    <passability>Impassable</passability>
+    <designationCategory>Misc</designationCategory>
+    <drawerType>RealtimeOnly</drawerType>
+    <selectable>true</selectable>
+    <fillPercent>1</fillPercent>
+    <coversFloor>true</coversFloor>
+    <holdsRoof>true</holdsRoof>
+    <blockLight>true</blockLight>
+    <canOverlapZones>false</canOverlapZones>
+    <castEdgeShadows>true</castEdgeShadows>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <tickerType>Normal</tickerType>
+    <drawOffscreen>true</drawOffscreen>
+    <category>Building</category>
+    <altitudeLayer>Building</altitudeLayer>
+    <size>(1, 1)</size>
+    <rotatable>false</rotatable>
+    <costList>
+      <RF_GildedPlasteel>100</RF_GildedPlasteel>
+      <RF_Copper>50</RF_Copper>
+      <ComponentSpacer>12</ComponentSpacer>
+    </costList>
+    <comps>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <transmitsPower>false</transmitsPower>
+        <shortCircuitInRain>false</shortCircuitInRain>
+        <basePowerConsumption>50</basePowerConsumption>
+      </li>
+      <li Class="CompProperties_Flickable"></li>
+    </comps>
+    <researchPrerequisites>
+      <li>RF_Research_Greenhouses</li>
+    </researchPrerequisites>
+    <statBases>
+      <MaxHitPoints>100</MaxHitPoints>
+      <WorkToBuild>5000</WorkToBuild>
+      <Flammability>0.25</Flammability>
+      <Beauty>-2</Beauty>
+      <Cleanliness>2</Cleanliness>
+      <Mass>30</Mass>
+    </statBases>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <thingCategories>
+      <li>BuildingsMisc</li>
+    </thingCategories>
+    <constructionSkillPrerequisite>5</constructionSkillPrerequisite>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Buildings/HeatingElements.xml
+++ b/1.6/Defs/Buildings/HeatingElements.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef Name="RF_HeatingElementBase" ParentName="RF_BuildingBase" Abstract="True">
+    <size>(2, 2)</size>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <thingCategories>
+      <li>BuildingsProduction</li>
+    </thingCategories>
+    <graphicData>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(3,3)</drawSize>
+      <drawOffset>(0,0,0.5)</drawOffset>
+    </graphicData>
+    <rotatable>false</rotatable>
+    <tickerType>Normal</tickerType>
+    <drawerType>RealtimeOnly</drawerType>
+    <altitudeLayer>LayingPawn</altitudeLayer>
+    <comps></comps>
+    <placeWorkers>
+      <li>PlaceWorker_Heater</li>
+    </placeWorkers>
+    <researchPrerequisites>
+      <li>RF_Research_Forge</li>
+    </researchPrerequisites> 
+  </ThingDef>
+
+  <RimForge.HeatingElementDef ParentName="RF_HeatingElementBase">
+    <defName>RF_WoodHeatingElement</defName>
+    <thingClass>RimForge.Buildings.Building_FueledHeatingElement</thingClass>
+    <label>wood-fired heating element</label>
+    <description>A heating element, to provide heat to a forge.
+This one burns wood to produce heat.</description>
+    <graphicData>
+      <texPath>RF/Buildings/HeatingElement_FueledIdle</texPath>
+    </graphicData>
+    <costList>
+      <Steel>100</Steel>
+      <ComponentIndustrial>4</ComponentIndustrial>
+    </costList>
+
+    <!-- Means that with 2 wood-fired heaters, it is possible to make bronze, for tribal playthroughs. -->
+    <maxAddedHeat>500</maxAddedHeat>
+    <activeFuelBurnRate>200</activeFuelBurnRate>
+
+    <comps>
+      <li Class="CompProperties_Refuelable">
+        <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
+        <fuelConsumptionRate>0.0</fuelConsumptionRate>
+        <fuelCapacity>200.0</fuelCapacity>
+        <fuelFilter>
+          <thingDefs>
+            <li>WoodLog</li>
+          </thingDefs>
+        </fuelFilter>
+        <autoRefuelPercent>0.75</autoRefuelPercent>
+        <showFuelGizmo>true</showFuelGizmo>
+        <drawOutOfFuelOverlay>true</drawOutOfFuelOverlay>
+        <drawFuelGaugeInMap>false</drawFuelGaugeInMap>
+        <showAllowAutoRefuelToggle>true</showAllowAutoRefuelToggle>
+      </li>
+      <li Class="CompProperties_Glower">
+        <glowRadius>5</glowRadius>
+        <glowColor>(255, 138, 20, 0)</glowColor>
+      </li>
+    </comps>    
+
+  </RimForge.HeatingElementDef>
+
+  <RimForge.HeatingElementDef ParentName="RF_HeatingElementBase">
+    <defName>RF_ChemfuelHeatingElement</defName>
+    <thingClass>RimForge.Buildings.Building_FueledHeatingElement</thingClass>
+    <label>chemfuel heating element</label>
+    <description>A heating element, to provide heat to a forge.
+This one burns chemfuel to produce heat, an upgrade from burning wood.</description>
+    <graphicData>
+      <texPath>RF/Buildings/HeatingElement_FueledIdle</texPath>
+    </graphicData>
+    <costList>
+      <Steel>200</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+    </costList>
+
+    <maxAddedHeat>800</maxAddedHeat>
+    <activeFuelBurnRate>200</activeFuelBurnRate>
+
+    <comps>
+      <li Class="CompProperties_Refuelable">
+        <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
+        <fuelConsumptionRate>0.0</fuelConsumptionRate>
+        <fuelCapacity>200.0</fuelCapacity>
+        <fuelFilter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </fuelFilter>
+        <autoRefuelPercent>0.75</autoRefuelPercent>
+        <showFuelGizmo>true</showFuelGizmo>
+        <drawOutOfFuelOverlay>true</drawOutOfFuelOverlay>
+        <drawFuelGaugeInMap>false</drawFuelGaugeInMap>
+        <showAllowAutoRefuelToggle>true</showAllowAutoRefuelToggle>
+      </li>
+      <li Class="CompProperties_Glower">
+        <glowRadius>5</glowRadius>
+        <glowColor>(255, 138, 20, 0)</glowColor>
+      </li>
+    </comps>    
+
+  </RimForge.HeatingElementDef>
+
+  <RimForge.HeatingElementDef ParentName="RF_HeatingElementBase">
+    <defName>RF_PoweredHeatingElement</defName>
+    <thingClass>RimForge.Buildings.Building_PoweredHeatingElement</thingClass>
+    <label>arc-furnace heating element</label>
+    <description>A heating element, to provide heat to a forge.
+Makes use of an electric arc to directly heat the forge contents. Very high peak temperature at the cost of a large power consumption.
+Only consumes power when the forge is active.</description>
+    <graphicData>
+      <texPath>RF/Buildings/HeatingElement_PoweredIdle</texPath>
+    </graphicData>
+    <costList>
+      <Steel>300</Steel>
+      <ComponentSpacer>2</ComponentSpacer>
+    </costList>
+
+    <maxAddedHeat>1000</maxAddedHeat>
+    <activePowerDraw>2000</activePowerDraw> <!-- Uses 2KW at 100% power -->
+
+    <comps>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <shortCircuitInRain>false</shortCircuitInRain>
+        <basePowerConsumption>20</basePowerConsumption>
+      </li>
+      <li Class="CompProperties_Glower">
+        <glowRadius>5</glowRadius>
+        <glowColor>(255, 138, 20, 0)</glowColor>
+      </li>
+    </comps>    
+
+  </RimForge.HeatingElementDef>
+
+</Defs>

--- a/1.6/Defs/Buildings/LightningRod.xml
+++ b/1.6/Defs/Buildings/LightningRod.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef Name="RF_LightningRodBase" ParentName="BuildingBase" Abstract="True">
+    <thingClass>RimForge.Buildings.Building_LightningRod</thingClass>
+    <graphicData>
+      <texPath>RF/Buildings/LightningRod</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1,2)</drawSize>
+      <drawOffset>(0, 0, 0.5)</drawOffset>
+    </graphicData>
+    <passability>PassThroughOnly</passability>
+    <designationCategory>Power</designationCategory>
+    <drawerType>MapMeshAndRealTime</drawerType>
+    <selectable>true</selectable>
+    <canOverlapZones>true</canOverlapZones>
+    <castEdgeShadows>false</castEdgeShadows>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <tickerType>Never</tickerType>
+    <category>Building</category>
+    <altitudeLayer>BuildingOnTop</altitudeLayer>
+    <pathCost>20</pathCost>
+    <size>(1, 1)</size>
+    <costList>
+      <Steel>20</Steel>
+      <ComponentIndustrial>4</ComponentIndustrial>
+      <RF_Copper>50</RF_Copper>
+    </costList>
+    <statBases>
+      <MaxHitPoints>100</MaxHitPoints>
+      <WorkToBuild>5000</WorkToBuild>
+      <Flammability>0.25</Flammability>
+      <Beauty>-2</Beauty>
+      <Cleanliness>2</Cleanliness>
+      <Mass>30</Mass>
+    </statBases>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <placeWorkers>
+      <li>PlaceWorker_NotUnderRoof</li>
+    </placeWorkers>
+    <thingCategories>
+      <li>BuildingsPower</li>
+    </thingCategories>
+    <constructionSkillPrerequisite>5</constructionSkillPrerequisite>
+    <comps>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <transmitsPower>true</transmitsPower>
+        <shortCircuitInRain>false</shortCircuitInRain>
+        <basePowerConsumption>0</basePowerConsumption>
+      </li>
+    </comps>
+    <researchPrerequisites>
+      <li>Electricity</li>
+    </researchPrerequisites>
+  </ThingDef>
+
+  <!-- Normal version -->
+  <ThingDef ParentName="RF_LightningRodBase">
+    <defName>RF_LightningRod</defName>
+    <label>lightning rod</label>
+    <description>A tall metal structure designed to attract lightning strikes.
+All lightning bolts in a large area around this rod will be attracted to it, and will generate large amount of power!</description>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Buildings/RitualCore.xml
+++ b/1.6/Defs/Buildings/RitualCore.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BuildingBase">
+    <defName>RF_RitualCore</defName>
+    <label>ritual core</label>
+    <description>The center-piece of the blessing ritual.
+Once the other parts of the ritual have been placed down, and the conditions are right, the ritual may begin.
+
+Praise the machine god!</description>
+    <thingClass>RimForge.Buildings.Building_RitualCore</thingClass>
+    <graphicData>
+      <texPath>RF/Buildings/RitualCoreActive</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1,2)</drawSize>
+      <drawOffset>(0,0,0.5)</drawOffset>
+    </graphicData>
+    <passability>PassThroughOnly</passability>
+    <designationCategory>Misc</designationCategory>
+    <drawerType>RealtimeOnly</drawerType>
+    <selectable>true</selectable>
+    <canOverlapZones>true</canOverlapZones>
+    <castEdgeShadows>true</castEdgeShadows>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <tickerType>Normal</tickerType>
+    <drawOffscreen>true</drawOffscreen>
+    <category>Building</category>
+    <altitudeLayer>BuildingOnTop</altitudeLayer>
+    <pathCost>20</pathCost>
+    <size>(1, 1)</size>
+    <researchPrerequisites>
+      <li>RF_Research_Ritual</li>
+    </researchPrerequisites>
+    <costList>
+      <Steel>20</Steel>
+      <ComponentIndustrial>4</ComponentIndustrial>
+      <RF_Copper>50</RF_Copper>
+    </costList>
+    <comps>
+      <li Class="CompProperties_Glower">
+        <glowRadius>12</glowRadius>
+        <glowColor>(255,89,0,0)</glowColor>
+      </li>
+    </comps>
+    <statBases>
+      <MaxHitPoints>100</MaxHitPoints>
+      <WorkToBuild>5000</WorkToBuild>
+      <Flammability>0.25</Flammability>
+      <Beauty>-2</Beauty>
+      <Cleanliness>2</Cleanliness>
+      <Mass>30</Mass>
+    </statBases>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <thingCategories>
+      <li>BuildingsMisc</li>
+    </thingCategories>
+    <constructionSkillPrerequisite>5</constructionSkillPrerequisite>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Buildings/TeslaCoils.xml
+++ b/1.6/Defs/Buildings/TeslaCoils.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef Name="RF_TeslaCoilBase" ParentName="BuildingBase" Abstract="True">
+    <thingClass>RimForge.Buildings.Building_TeslaCoil</thingClass>
+    <graphicData>
+      <texPath>RF/Buildings/TeslaCoil</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1,2)</drawSize>
+      <drawOffset>(0, 0, 0.5)</drawOffset>
+    </graphicData>
+    <passability>PassThroughOnly</passability>
+    <designationCategory>Security</designationCategory>
+    <drawerType>RealtimeOnly</drawerType>
+    <selectable>true</selectable>
+    <canOverlapZones>true</canOverlapZones>
+    <castEdgeShadows>false</castEdgeShadows>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <tickerType>Normal</tickerType>
+    <category>Building</category>
+    <altitudeLayer>BuildingOnTop</altitudeLayer>
+    <pathCost>20</pathCost>
+    <size>(1, 1)</size>
+    <building>
+      <ai_combatDangerous>true</ai_combatDangerous>
+    </building>
+    <costList>
+      <Steel>20</Steel>
+      <ComponentIndustrial>10</ComponentIndustrial>
+      <RF_Copper>50</RF_Copper>
+    </costList>
+    <statBases>
+      <MaxHitPoints>100</MaxHitPoints>
+      <WorkToBuild>5000</WorkToBuild>
+      <Flammability>0.25</Flammability>
+      <Beauty>-8</Beauty>
+      <Cleanliness>-2</Cleanliness>
+      <Mass>50</Mass>
+    </statBases>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <thingCategories>
+      <li>BuildingsSecurity</li>
+    </thingCategories>
+    <comps>
+      <li Class="CompProperties_Flickable" />
+    </comps>
+    <constructionSkillPrerequisite>5</constructionSkillPrerequisite>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+    </researchPrerequisites>
+  </ThingDef>
+
+  <!-- Wireless version -->
+  <ThingDef ParentName="RF_TeslaCoilBase">
+    <defName>RF_TeslaCoilWireless</defName>
+    <label>tesla coil (wireless)</label>
+    <description>When two are linked, they will discharge an electrical arc whenever enemies pass between them.
+Note: one coil is the 'active' coil and one is the 'passive'. The active one is the one that fires and goes on cooldown. The passive one simply serves as the endpoint for the electrical arc.
+A tesla coil can be both 'active' and 'passive' at the same time, allowing you to create chains of tesla coils.
+
+This is a wireless version, so it must be powered by linking to to a wireless power channel.</description>
+    <comps>
+      <li Class="RimForge.Comps.CompProperties_WirelessPower">
+        <buildingName>tesla coil</buildingName>
+        <canSendPower>false</canSendPower>
+        <fixedPowerLevel>600</fixedPowerLevel>
+      </li>
+    </comps>
+  </ThingDef>
+
+  <!-- Wired version -->
+  <ThingDef ParentName="RF_TeslaCoilBase">
+    <defName>RF_TeslaCoil</defName>
+    <label>tesla coil</label>
+    <description>When two are linked, they will discharge an electrical arc whenever enemies pass between them.
+Note: one coil is the 'active' coil and one is the 'passive'. The active one is the one that fires and goes on cooldown. The passive one simply serves as the endpoint for the electrical arc.
+A tesla coil can be both 'active' and 'passive' at the same time, allowing you to create chains of tesla coils.</description>
+    <comps>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <transmitsPower>false</transmitsPower>
+        <shortCircuitInRain>false</shortCircuitInRain>
+        <basePowerConsumption>600</basePowerConsumption>
+      </li>
+    </comps>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Buildings/WirelessPowerPylon.xml
+++ b/1.6/Defs/Buildings/WirelessPowerPylon.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BuildingBase">
+    <defName>RF_WirelessPowerPylon</defName>
+    <thingClass>RimForge.Buildings.Building_WirelessPowerPylon</thingClass>
+    <label>wireless power pylon</label>
+    <description>Transmits or receives electrical power wirelessly. No more ugly cables.</description>
+    <graphicData>
+      <texPath>RF/Buildings/PylonIdle</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1,2)</drawSize>
+      <drawOffset>(0, 0, 0.5)</drawOffset>
+    </graphicData>
+    <passability>PassThroughOnly</passability>
+    <designationCategory>Power</designationCategory>
+    <drawerType>RealtimeOnly</drawerType>
+    <selectable>true</selectable>
+    <canOverlapZones>true</canOverlapZones>
+    <castEdgeShadows>true</castEdgeShadows>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <tickerType>Normal</tickerType>
+    <category>Building</category>
+    <altitudeLayer>BuildingOnTop</altitudeLayer>
+    <pathCost>20</pathCost>
+    <size>(1, 1)</size>
+    <costList>
+      <Steel>20</Steel>
+      <ComponentIndustrial>3</ComponentIndustrial>
+      <RF_Copper>30</RF_Copper>
+    </costList>
+    <statBases>
+        <MaxHitPoints>100</MaxHitPoints>
+        <WorkToBuild>5000</WorkToBuild>
+        <Flammability>0.25</Flammability>
+        <Beauty>-2</Beauty>
+        <Cleanliness>1</Cleanliness>
+        <Mass>10</Mass>
+      </statBases>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <thingCategories>
+      <li>BuildingsPower</li>
+    </thingCategories>
+    <comps>
+      <li Class="CompProperties_Glower">
+        <glowRadius>3</glowRadius>
+        <glowColor>(200,200,255,255)</glowColor>
+      </li>
+      <li Class="CompProperties_Flickable"/>
+      <li Class="CompProperties_Power">
+        <compClass>CompPowerTrader</compClass>
+        <transmitsPower>true</transmitsPower>
+        <shortCircuitInRain>false</shortCircuitInRain>
+        <basePowerConsumption>0</basePowerConsumption>
+      </li>
+      <li Class="RimForge.Comps.CompProperties_WirelessPower">
+        <buildingName>pylon</buildingName>
+        <canSendPower>true</canSendPower>
+      </li>
+    </comps>
+    <constructionSkillPrerequisite>5</constructionSkillPrerequisite>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+    </researchPrerequisites>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Crops/MercuryBloom.xml
+++ b/1.6/Defs/Crops/MercuryBloom.xml
@@ -1,0 +1,38 @@
+<Defs>
+  <ThingDef ParentName="PlantBase">
+    <defName>RF_Plant_MercuryBloom</defName>
+    <label>mercury bloom</label>
+    <description>A Mercury Bloom plant.
+It seems that this plant is especially efficient at absorbing the mercury naturally present in the soil.
+This mercury is a key ingredient in making Mercury Ultraweave.</description>
+    <statBases>
+      <MaxHitPoints>85</MaxHitPoints>
+      <Nutrition>0.1</Nutrition>
+    </statBases>
+    <graphicData>
+      <texPath>Things/Plant/CottonPlant</texPath>
+      <graphicClass>Graphic_Random</graphicClass>
+    </graphicData>
+    <selectable>true</selectable>
+    <pathCost>14</pathCost>
+    <ingestible />
+    <researchPrerequisites>
+      <li>RF_Research_Mercury</li>
+    </researchPrerequisites>
+    <plant>
+      <growDays>10</growDays>
+      <dieIfLeafless>true</dieIfLeafless>
+      <harvestTag>Standard</harvestTag>
+      <harvestedThingDef>RF_Mercury</harvestedThingDef>
+      <harvestYield>4</harvestYield>
+      <sowTags>
+        <li>Ground</li>
+        <li>Hydroponic</li>
+      </sowTags>
+      <topWindExposure>0.1</topWindExposure>
+      <immatureGraphicPath>Things/Plant/CottonPlant_Immature</immatureGraphicPath>
+      <visualSizeRange>0.3~1.05</visualSizeRange>
+      <wildOrder>2</wildOrder>
+    </plant>
+  </ThingDef>
+</Defs>

--- a/1.6/Defs/DamageDefs/DamageDefs.xml
+++ b/1.6/Defs/DamageDefs/DamageDefs.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <DamageDef ParentName="StunBase">
+    <defName>RF_Electrocution</defName>
+    <label>Electrical</label>
+    <workerClass>RimForge.Damage.DamageWorker_Electrical</workerClass>
+    <externalViolence>true</externalViolence>
+    <deathMessage>{0} has been electocuted to death.</deathMessage>
+    <harmsHealth>true</harmsHealth>
+    <impactSoundType>Electric</impactSoundType>
+    <defaultDamage>35</defaultDamage>
+    <explosionSnowMeltAmount>0</explosionSnowMeltAmount>
+    <explosionCellFleck>BlastEMP</explosionCellFleck>
+    <explosionColorEdge>(0.8, 0.8, 0.8, 0.8)</explosionColorEdge>
+    <explosionInteriorFleck>ElectricalSpark</explosionInteriorFleck>
+    <soundExplosion>Explosion_EMP</soundExplosion>
+    <combatLogRules>Damage_EMP</combatLogRules>
+    <armorCategory>Heat</armorCategory> <!-- IDK why not -->
+    <hediff>RF_ElectricalBurn</hediff>
+  </DamageDef>
+
+  <!-- Electrical burn hediff -->
+  <HediffDef ParentName="InjuryBase">
+    <defName>RF_ElectricalBurn</defName>
+    <label>electrical burn</label>
+    <labelNoun>an electrical burn</labelNoun>
+    <description>An electrical burn, the result of a high amperage electrical current flowing through the body.
+Very painful.</description>
+    <comps>
+      <li Class="HediffCompProperties_TendDuration">
+        <labelTendedWell>bandaged</labelTendedWell>
+        <labelTendedWellInner>tended</labelTendedWellInner>
+        <labelSolidTendedWell>tended</labelSolidTendedWell>
+      </li>
+      <li Class="HediffCompProperties_Infecter">
+        <infectionChance>0.3</infectionChance>
+      </li>
+      <li Class="HediffCompProperties_GetsPermanent">
+        <permanentLabel>electrical burn scar</permanentLabel>
+      </li>
+    </comps>
+    <injuryProps>
+      <painPerSeverity>0.036</painPerSeverity> <!-- Very high -->
+      <averagePainPerSeverityPermanent>0.00325</averagePainPerSeverityPermanent>
+      <canMerge>true</canMerge>
+      <destroyedLabel>Burned off (electrical)</destroyedLabel>
+      <destroyedOutLabel>Burned out (electrical)</destroyedOutLabel>
+    </injuryProps>
+  </HediffDef>
+
+  <DamageDef>
+    <defName>RF_CoilgunDamage</defName>
+    <label>coilgun slug</label>
+    <workerClass>RimForge.Damage.DamageWorker_Propagate</workerClass>
+    <externalViolence>true</externalViolence>
+    <deathMessage>{0} has been killed by a coilgun blast.</deathMessage>
+    <hediff>RF_CoilgunSlugHediff</hediff>
+    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
+    <impactSoundType>Bullet</impactSoundType>
+    <armorCategory>Sharp</armorCategory>
+    <overkillPctToDestroyPart>0~0.7</overkillPctToDestroyPart>
+    <minDamageToFragment>50</minDamageToFragment>
+    <isRanged>true</isRanged>
+    <makesAnimalsFlee>true</makesAnimalsFlee>
+  </DamageDef>
+
+  <!-- Coilgun shot hediff -->
+  <HediffDef ParentName="InjuryBase">
+    <defName>RF_CoilgunSlugHediff</defName>
+    <label>coilgun cannon gunshot</label>
+    <labelNoun>a coilgun cannon wound</labelNoun>
+    <description>A would caused by being directly hit by a Liandry Coilgun. Ouch.</description>
+    <comps>
+      <li Class="HediffCompProperties_TendDuration">
+        <labelTendedWell>bandaged</labelTendedWell>
+        <labelTendedWellInner>sutured</labelTendedWellInner>
+        <labelSolidTendedWell>set</labelSolidTendedWell>
+      </li>
+      <li Class="HediffCompProperties_Infecter">
+        <infectionChance>0.15</infectionChance>
+      </li>
+      <li Class="HediffCompProperties_GetsPermanent">
+        <permanentLabel>old coilgun gunshot</permanentLabel>
+        <instantlyPermanentLabel>permanent coilgun gunshot injury</instantlyPermanentLabel>
+      </li>
+    </comps>
+    <injuryProps>
+      <painPerSeverity>0.0225</painPerSeverity>
+      <averagePainPerSeverityPermanent>0.00725</averagePainPerSeverityPermanent>
+      <bleedRate>0.15</bleedRate>
+      <canMerge>false</canMerge>
+      <destroyedLabel>Shot off (coilgun)</destroyedLabel>
+      <destroyedOutLabel>Shot out (coilgun)</destroyedOutLabel>
+    </injuryProps>
+  </HediffDef>
+
+  <DamageDef>
+    <defName>RF_RitualDamage</defName>
+    <label>offering</label>
+    <workerClass>DamageWorker_AddInjury</workerClass>
+    <externalViolence>true</externalViolence>
+    <deathMessage>{0} has been sacrificed to machine god Zir.</deathMessage>
+    <hediff>RF_RitualDamageHediff</hediff>
+  </DamageDef>
+
+  <!-- Ritual hediff -->
+  <HediffDef ParentName="InjuryBase">
+    <defName>RF_RitualDamageHediff</defName>
+    <label>consumed by Zir</label>
+    <labelNoun>offered to machine god Zir</labelNoun>
+    <description>Machine god Zir has exchanged this mortal flesh for a blessing.</description>
+    <injuryProps>
+      <painPerSeverity>1</painPerSeverity>
+      <averagePainPerSeverityPermanent>0.00725</averagePainPerSeverityPermanent>
+      <bleedRate>0</bleedRate>
+      <canMerge>false</canMerge>
+      <destroyedLabel>Consumed by Zir</destroyedLabel>
+      <destroyedOutLabel>Consumed by Zir</destroyedOutLabel>
+    </injuryProps>
+  </HediffDef>
+
+  <!-- Custom HE shell damage worker, to track explosion kills -->
+  <DamageDef ParentName="Bomb">
+    <defName>RF_ShellHE_Bomb</defName>
+    <workerClass>RimForge.Damage.DamageWorker_AddInjuryForShellHE</workerClass>
+  </DamageDef>
+
+</Defs>

--- a/1.6/Defs/Floors/Alloy Floors.xml
+++ b/1.6/Defs/Floors/Alloy Floors.xml
@@ -1,0 +1,90 @@
+<Defs>
+
+  <TerrainDef ParentName="TileMetalBase">
+    <defName>RF_Floor_Bronze</defName>
+    <label>bronze tiles</label>
+    <renderPrecedence>244</renderPrecedence>
+    <description>Rather ugly bronze tiles, laid into the floor.\nFast to place down and quite inexpensive.</description>
+    <texturePath>RF/Floors/Bronze</texturePath>
+    <color>(1, 1, 1)</color>
+    <statBases>
+      <Beauty>-1</Beauty>
+      <WorkToBuild>500</WorkToBuild>
+      <Cleanliness>0.1</Cleanliness>
+    </statBases>
+    <costList>
+      <RF_Bronze>4</RF_Bronze>
+    </costList>
+    <constructEffect>ConstructMetal</constructEffect>
+    <researchPrerequisites>
+      <li>Smithing</li>
+    </researchPrerequisites>
+  </TerrainDef>
+
+  <TerrainDef ParentName="TileMetalBase">
+    <defName>RF_Floor_Copper</defName>
+    <label>copper tiles</label>
+    <renderPrecedence>245</renderPrecedence>
+    <description>Copper tiles, laid into the floor.\nRequires a lot of copper and time to construct, but once placed down the tiles offer a bonus to cleanliness.</description>
+    <texturePath>RF/Floors/Copper</texturePath>
+    <color>(1, 1, 1)</color>
+    <statBases>
+      <Beauty>0</Beauty>
+      <WorkToBuild>1400</WorkToBuild>
+      <Cleanliness>0.5</Cleanliness>
+    </statBases>
+    <costList>
+      <RF_Copper>10</RF_Copper>
+    </costList>
+    <constructEffect>ConstructMetal</constructEffect>
+    <researchPrerequisites>
+      <li>Smithing</li>
+    </researchPrerequisites>
+  </TerrainDef>
+
+  <TerrainDef ParentName="TileMetalBase">
+    <defName>RF_Floor_Tin</defName>
+    <label>tin tiles</label>
+    <renderPrecedence>246</renderPrecedence>
+    <description>Tin tiles, laid into the floor.\nQuite pleasant to look at and mostly sterile.</description>
+    <texturePath>RF/Floors/Tin</texturePath>
+    <color>(1, 1, 1)</color>
+    <statBases>
+      <Beauty>1</Beauty>
+      <WorkToBuild>1200</WorkToBuild>
+      <Cleanliness>0.25</Cleanliness>
+    </statBases>
+    <costList>
+      <RF_Tin>8</RF_Tin>
+    </costList>
+    <constructEffect>ConstructMetal</constructEffect>
+    <researchPrerequisites>
+      <li>Smithing</li>
+    </researchPrerequisites>
+  </TerrainDef>
+
+  <TerrainDef ParentName="TileMetalBase">
+    <defName>RF_Floor_Adamantium</defName>
+    <label>adamantium tiles</label>
+    <renderPrecedence>247</renderPrecedence>
+    <description>Adamantium tiles, laid into the floor.\nSterile, beautiful, and very extravagant.</description>
+    <texturePath>RF/Floors/Adamantium</texturePath>
+    <color>(1, 1, 1)</color>
+    <statBases>
+      <Beauty>30</Beauty>
+      <WorkToBuild>2500</WorkToBuild>
+      <Cleanliness>1</Cleanliness>
+    </statBases>
+    <costList>
+      <RF_Adamantium>8</RF_Adamantium>
+    </costList>
+    <constructEffect>ConstructMetal</constructEffect>
+    <researchPrerequisites>
+      <li>Smithing</li>
+    </researchPrerequisites>
+    <tags>
+      <li>FineFloor</li>
+    </tags>
+  </TerrainDef>
+
+</Defs>

--- a/1.6/Defs/Items/CoilgunShells.xml
+++ b/1.6/Defs/Items/CoilgunShells.xml
@@ -1,0 +1,247 @@
+<Defs>
+  <RimForge.CoilgunShellDef Name="RF_CoilgunShellBase" ParentName="ResourceBase" Abstract="true">
+    <thingClass>ThingWithComps</thingClass>
+    <resourceReadoutPriority>Middle</resourceReadoutPriority>
+    <useHitPoints>true</useHitPoints>
+    <graphicData>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <thingCategories>
+      <li>Items</li>
+    </thingCategories>
+    <statBases>
+      <MaxHitPoints>20</MaxHitPoints>
+      <Mass>4</Mass>
+      <DeteriorationRate>0.5</DeteriorationRate>
+      <Flammability>0</Flammability>
+    </statBases>
+    <tradeTags>
+      <li>ExoticMisc</li>
+    </tradeTags>
+    <researchPrerequisites>
+      <li>RF_Research_Coilgun</li>
+    </researchPrerequisites>
+    <techLevel>Spacer</techLevel>
+    <soundInteract>Metal_Drop</soundInteract>
+    <soundDrop>Metal_Drop</soundDrop>
+    <healthAffectsPrice>false</healthAffectsPrice>
+    <tradeability>Sellable</tradeability>
+    <stackLimit>10</stackLimit>
+    <burnableByRecipe>false</burnableByRecipe>
+    <smeltable>false</smeltable>
+  </RimForge.CoilgunShellDef>
+
+  <!-- DEFS -->
+
+  <RimForge.CoilgunShellDef ParentName="RF_CoilgunShellBase">
+    <defName>RF_CoilgunShellAP</defName>
+    <label>Coilgun shell (AP)</label>
+    <description>A shell fired by the Liandry Coilgun.
+This is the armor-piercing variant, that can travel through many surfaces and hit many targets.
+Very effective against infantry and small mechanoids and useful for destroying specific enemy structures.</description>
+    <graphicData>
+      <texPath>RF/Items/CoilgunShell_AP</texPath>
+    </graphicData>
+
+    <!-- Shell properties -->
+    <maxPen>-1</maxPen> <!-- Does not have a maximum pen depth, it just keeps going -->
+    <baseDamage>120</baseDamage>
+    <penDamageMultiplier>0.985</penDamageMultiplier> <!-- Slightly less damage after each surface pen. -->
+
+  </RimForge.CoilgunShellDef>
+
+  <RimForge.CoilgunShellDef ParentName="RF_CoilgunShellBase">
+    <defName>RF_CoilgunShellSP</defName>
+    <label>Coilgun shell (SP)</label>
+    <description>A shell fired by the Liandry Coilgun.
+This is the soft-point variant. It will penetrate only a few surfaces but will deal much higher damage upon impact.
+Because of this poor penetration, it requires line of sight to be effective. Very effective against large mechanoids and large groups of enemies.</description>
+    <graphicData>
+      <texPath>RF/Items/CoilgunShell_SP</texPath>
+    </graphicData>
+
+    <!-- Shell properties -->
+    <maxPen>5</maxPen> <!-- Can only go through 5 surfaces before completely stopping. --> 
+    <baseDamage>700</baseDamage>
+    <penDamageMultiplier>0.75</penDamageMultiplier>
+
+  </RimForge.CoilgunShellDef>
+
+  <RimForge.CoilgunShellDef ParentName="RF_CoilgunShellBase">
+    <defName>RF_CoilgunShellHE</defName>
+    <label>Coilgun shell (HE)</label>
+    <description>A shell fired by the Liandry Coilgun.
+This is the high-explosive variant. It will violently explode upon hitting a solid object, killing the target and anyone standing within a 7m radius.
+Vegetation such as trees and bushes will not interrupt the projectile's flight.
+Most effective against large groups of enemies.</description>
+    <graphicData>
+      <texPath>RF/Items/CoilgunShell_HE</texPath>
+    </graphicData>
+    <tickerType>Normal</tickerType>
+    <comps>
+      <li Class="CompProperties_Explosive">
+        <explosiveRadius>3.5</explosiveRadius>
+        <explosiveDamageType>Bomb</explosiveDamageType>
+        <explosiveExpandPerStackcount>0.75</explosiveExpandPerStackcount>
+        <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
+        <wickTicks>30~60</wickTicks>
+      </li>
+    </comps>
+
+    <!-- Shell properties -->
+    <maxPen>0</maxPen> <!-- Can only go through 5 surfaces before completely stopping. --> 
+    <baseDamage>200</baseDamage> <!-- Directly deals 200 damage -->
+    <useHEKillTracker>true</useHEKillTracker>
+    <explosionDamage>65</explosionDamage> <!-- The explosion damage. Decreases based on distance from explosion center -->
+    <explosionDamageType>RF_ShellHE_Bomb</explosionDamageType>
+    <explosionArmorPen>1.3</explosionArmorPen>
+    <explosionRadius>10</explosionRadius>
+    <pawnsCountAsPen>true</pawnsCountAsPen>
+  </RimForge.CoilgunShellDef>
+
+  <!-- RECIPES -->
+  <RecipeDef>
+    <defName>RF_Make_CoilgunShellAP</defName>
+    <label>make a coilgun shell (AP)</label>
+    <description>Make an armor-piercing coilgun shell.</description>
+    <jobString>Making a coilgun shell (AP).</jobString>
+    <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+    <effectWorking>Cook</effectWorking>
+    <recipeUsers>
+      <li>TableMachining</li>
+    </recipeUsers>
+    <researchPrerequisite>RF_Research_Coilgun</researchPrerequisite>
+    <soundWorking>Recipe_Machining</soundWorking>
+    <workAmount>1100</workAmount>
+    <unfinishedThingDef>UnfinishedComponent</unfinishedThingDef>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>RF_Staballoy</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>RF_Staballoy</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <RF_CoilgunShellAP>1</RF_CoilgunShellAP>
+    </products>
+    <skillRequirements>
+      <Crafting>7</Crafting>
+    </skillRequirements>
+    <workSkill>Crafting</workSkill>
+  </RecipeDef>
+
+  <RecipeDef>
+    <defName>RF_Make_CoilgunShellSP</defName>
+    <label>make a coilgun shell (SP)</label>
+    <description>Make a soft-point coilgun shell.</description>
+    <jobString>Making a coilgun shell (SP).</jobString>
+    <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+    <effectWorking>Cook</effectWorking>
+    <recipeUsers>
+      <li>TableMachining</li>
+    </recipeUsers>
+    <researchPrerequisite>RF_Research_Coilgun</researchPrerequisite>
+    <soundWorking>Recipe_Machining</soundWorking>
+    <workAmount>1100</workAmount>
+    <unfinishedThingDef>UnfinishedComponent</unfinishedThingDef>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>RF_Staballoy</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>15</count>
+      </li>
+    </ingredients>
+
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>RF_Staballoy</li>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <RF_CoilgunShellSP>1</RF_CoilgunShellSP>
+    </products>
+    <skillRequirements>
+      <Crafting>7</Crafting>
+    </skillRequirements>
+    <workSkill>Crafting</workSkill>
+  </RecipeDef>
+
+  <RecipeDef>
+    <defName>RF_Make_CoilgunShellHE</defName>
+    <label>make a coilgun shell (HE)</label>
+    <description>Make a high-explosive coilgun shell.</description>
+    <jobString>Making a coilgun shell (HE).</jobString>
+    <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+    <effectWorking>Cook</effectWorking>
+    <recipeUsers>
+      <li>TableMachining</li>
+    </recipeUsers>
+    <researchPrerequisite>RF_Research_Coilgun</researchPrerequisite>
+    <soundWorking>Recipe_Machining</soundWorking>
+    <workAmount>1100</workAmount>
+    <unfinishedThingDef>UnfinishedComponent</unfinishedThingDef>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>RF_Staballoy</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>RF_Staballoy</li>
+        <li>Steel</li>
+        <li>Chemfuel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <RF_CoilgunShellHE>1</RF_CoilgunShellHE>
+    </products>
+    <skillRequirements>
+      <Crafting>7</Crafting>
+    </skillRequirements>
+    <workSkill>Crafting</workSkill>
+  </RecipeDef>
+
+</Defs>

--- a/1.6/Defs/Letters/Letters.xml
+++ b/1.6/Defs/Letters/Letters.xml
@@ -1,0 +1,12 @@
+
+<Defs>
+  <LetterDef>
+    <defName>RF_CursedRaiders</defName>
+    <color>(30, 55, 30)</color>
+    <flashColor>(40, 80, 40)</flashColor>
+    <flashInterval>7</flashInterval>
+    <bounce>true</bounce>
+    <arriveSound>LetterArrive_BadUrgentSmall</arriveSound>
+    <pauseMode>MajorThreat</pauseMode>
+  </LetterDef>
+</Defs>

--- a/1.6/Defs/Motes/AirMote.xml
+++ b/1.6/Defs/Motes/AirMote.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+    <ThingDef ParentName="MoteBase">
+        <defName>RF_Motes_Air</defName>
+        <graphicData>
+            <texPath>RF/Motes/Air</texPath>
+            <shaderType>MoteGlow</shaderType>
+        </graphicData>
+        <altitudeLayer>MoteOverhead</altitudeLayer>
+        <drawOffscreen>false</drawOffscreen>
+        <mote>
+            <fadeInTime>0.25</fadeInTime>
+            <solidTime>0.3</solidTime>
+            <fadeOutTime>1.0</fadeOutTime>
+            <growthRate>-0.2</growthRate>
+        </mote>
+    </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Motes/GrowthMote.xml
+++ b/1.6/Defs/Motes/GrowthMote.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+    <ThingDef ParentName="MoteBase">
+        <defName>RF_Motes_Growth</defName>
+        <graphicData>
+            <texPath>RF/Motes/GrowthMotes/GrowthMote</texPath>
+            <shaderType>MoteGlow</shaderType>
+            <!-- <graphicClass>Graphic_Random</graphicClass> -->
+        </graphicData>
+        <altitudeLayer>MoteOverhead</altitudeLayer>
+        <drawOffscreen>false</drawOffscreen>
+        <mote>
+            <fadeInTime>0.2</fadeInTime>
+            <solidTime>0.3</solidTime>
+            <fadeOutTime>1.0</fadeOutTime>
+            <growthRate>-0.25</growthRate>
+            <rotateTowardsTarget>true</rotateTowardsTarget>
+        </mote>
+    </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Motes/MuzzleFlashMote.xml
+++ b/1.6/Defs/Motes/MuzzleFlashMote.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+    <ThingDef ParentName="MoteBase">
+        <defName>RF_Motes_MuzzleFlash</defName>
+        <graphicData>
+            <texPath>RF/Motes/MuzzleFlash</texPath>
+            <shaderType>MoteGlow</shaderType>
+        </graphicData>
+        <altitudeLayer>MoteOverhead</altitudeLayer>
+        <drawOffscreen>true</drawOffscreen>
+        <mote>
+            <fadeInTime>0</fadeInTime>
+            <solidTime>0</solidTime>
+            <fadeOutTime>1.2</fadeOutTime>
+        </mote>
+    </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Motes/RitualDistortMote.xml
+++ b/1.6/Defs/Motes/RitualDistortMote.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <FleckDef ParentName="FleckPsycastAreaEffect">
+    <defName>RF_Motes_RitualDistort</defName>
+    <altitudeLayer>MoteLow</altitudeLayer>
+    <fadeInTime>0.6</fadeInTime>
+    <fadeOutTime>0.6</fadeOutTime>
+    <solidTime>0.12</solidTime>
+    <growthRate>1.5</growthRate>
+    <graphicData>
+      <texPath>Things/Mote/Black</texPath>
+      <shaderParameters>
+        <_distortionIntensity>0.025</_distortionIntensity>
+        <_brightnessMultiplier>1.2</_brightnessMultiplier>
+      </shaderParameters>
+      <drawSize>6.5</drawSize>
+    </graphicData>
+  </FleckDef>
+
+</Defs>

--- a/1.6/Defs/Ores/RimForge Ores.xml
+++ b/1.6/Defs/Ores/RimForge Ores.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="RockBase">
+    <defName>RF_MineableCopper</defName>
+    <label>copper ore</label>
+    <description>A chunk of chalcopyrite, copper ore. Mining it yields pure copper, essential in the making of bronze and other alloys.
+Copper is also used in complex electronics.</description>
+    <graphicData>
+      <texPath>Things/Building/Linked/RockFlecked_Atlas</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <color>(128, 87, 38)</color>
+      <colorTwo>(199, 149, 90)</colorTwo>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>1000</MaxHitPoints>
+    </statBases>
+    <building>
+      <isResourceRock>true</isResourceRock>
+      <mineableThing>RF_Copper</mineableThing>
+      <mineableYield>60</mineableYield>
+      <mineableScatterCommonality>0.5</mineableScatterCommonality>
+      <mineableScatterLumpSizeRange>20~30</mineableScatterLumpSizeRange>
+    </building>
+  </ThingDef>
+
+  <ThingDef ParentName="RockBase">
+    <defName>RF_MineableTin</defName>
+    <label>tin ore</label>
+    <description>A chunk of cassiterite, tin ore. Mining it yields pure tin, essential in the making of bronze and other alloys.
+Tin is a soft metal with a low melting point, making it unsuitable for use as an armor or weapon material.</description>
+    <graphicData>
+      <texPath>Things/Building/Linked/RockFlecked_Atlas</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <color>(212, 205, 197)</color>
+      <colorTwo>(138, 137, 124)</colorTwo>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>500</MaxHitPoints>
+    </statBases>
+    <building>
+      <isResourceRock>true</isResourceRock>
+      <mineableThing>RF_Tin</mineableThing>
+      <mineableYield>50</mineableYield>
+      <mineableScatterCommonality>0.5</mineableScatterCommonality>
+      <mineableScatterLumpSizeRange>15~30</mineableScatterLumpSizeRange>
+    </building>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Research/Research.xml
+++ b/1.6/Defs/Research/Research.xml
@@ -1,0 +1,80 @@
+<Defs>
+
+  <ResearchProjectDef>
+    <defName>RF_Research_Coilgun</defName>
+    <label>liandry coilgun</label>
+    <description>Enables the construction of the Liandry Coilgun, a huge mounted coilgun that can fire through mountains.</description>
+    <baseCost>2500</baseCost>
+    <techLevel>Spacer</techLevel>
+    <prerequisites>
+      <li>GunTurrets</li>
+    </prerequisites>
+    <researchViewX>10.00</researchViewX>
+    <researchViewY>3.60</researchViewY>
+  </ResearchProjectDef>
+
+  <ResearchProjectDef>
+    <defName>RF_Research_Ritual</defName>
+    <label>Blessing of Zir ritual</label>
+    <description>Investigate the ritual that grants the Blessing of Zir at the cost of a human sacrifice.
+Enables you to build the Ritual Core.</description>
+    <baseCost>1000</baseCost>
+    <techLevel>Industrial</techLevel>
+    <researchViewX>0.00</researchViewX>
+    <researchViewY>5.45</researchViewY>
+  </ResearchProjectDef>
+
+  <ResearchProjectDef>
+    <defName>RF_Research_Forge</defName>
+    <label>alloy forge</label>
+    <description>Learn how the build the forge, a building that allows you to create powerful metal alloys.</description>
+    <baseCost>600</baseCost>
+    <techLevel>Medieval</techLevel>
+    <prerequisites>
+      <li>Smithing</li>
+    </prerequisites>
+    <researchViewX>2.00</researchViewX>
+    <researchViewY>4.25</researchViewY>
+  </ResearchProjectDef>
+
+  <ResearchProjectDef>
+    <defName>RF_Research_Mercury</defName>
+    <label>mercury harvesting</label>
+    <description>Learn to cultivate the Mercury Bloom plant, a source of pure mercury.
+Mercury is essential in the crafting of Mercury Ultraweave.</description>
+    <baseCost>1400</baseCost>
+    <techLevel>Industrial</techLevel>
+    <prerequisites>
+      <li>Devilstrand</li>
+    </prerequisites>
+    <researchViewX>1.00</researchViewX>
+    <researchViewY>5.45</researchViewY>
+  </ResearchProjectDef>
+
+  <ResearchProjectDef>
+    <defName>RF_Research_Greenhouses</defName>
+    <label>greenhouse controller</label>
+    <description>Build a greenhouse controller using advanced alloys, allowing your colonists to greatly increase the growing speed of indoor crops.</description>
+    <baseCost>1500</baseCost>
+    <techLevel>Industrial</techLevel>
+    <prerequisites>
+      <li>Hydroponics</li>
+    </prerequisites>
+    <researchViewX>7.00</researchViewX>
+    <researchViewY>0.00</researchViewY>
+  </ResearchProjectDef>
+
+  <ResearchProjectDef>
+    <defName>RF_Research_StrikeDrone</defName>
+    <label>strike drone</label>
+    <description>Enables the construction of an unmanned strike drone, capable of bombing targets on the local map.</description>
+    <baseCost>3000</baseCost>
+    <techLevel>Industrial</techLevel>
+    <prerequisites>
+      <li>Mortars</li>
+    </prerequisites>
+    <researchViewX>7.00</researchViewX>
+    <researchViewY>0.00</researchViewY>
+  </ResearchProjectDef>
+
+</Defs>

--- a/1.6/Defs/Resources/Adamantium.xml
+++ b/1.6/Defs/Resources/Adamantium.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="RF_AlloyResource">
+    <defName>RF_Adamantium</defName>
+    <label>adamantium</label>
+    <description>A complex alloy of Bronze, Staballoy and Gilded Plasteel.
+Unbelievably strong, and can be sharpened to a razor's edge without risk of it fracturing.
+Melee weapons built out of this material have a 50% chance to stop or deflect a bullet back at the shooter.</description>
+    <graphicData>
+      <texPath>RF/Resources/Adamantium</texPath>
+    </graphicData>
+    
+    <statBases>
+      <MarketValue>20</MarketValue>
+      <Mass>0.8</Mass>
+      <StuffPower_Armor_Sharp>2.2</StuffPower_Armor_Sharp>
+      <StuffPower_Armor_Blunt>2</StuffPower_Armor_Blunt>
+      <StuffPower_Armor_Heat>1.3</StuffPower_Armor_Heat>
+      <StuffPower_Insulation_Cold>2</StuffPower_Insulation_Cold>
+      <StuffPower_Insulation_Heat>2</StuffPower_Insulation_Heat>
+      <SharpDamageMultiplier>2.05</SharpDamageMultiplier>
+      <BluntDamageMultiplier>2.2</BluntDamageMultiplier>
+    </statBases>
+    <thingCategories>
+      <li>Alloys</li>
+    </thingCategories>
+    <deepCommonality>0</deepCommonality>
+    <stuffProps>
+      <categories>
+        <li>Metallic</li>
+      </categories>
+      <commonality>0</commonality>
+      <color>(37, 26, 54)</color>
+      <statFactors>
+        <MaxHitPoints>6</MaxHitPoints>
+        <Beauty>4.5</Beauty>
+        <Flammability>0</Flammability>
+        <WorkToMake>2.5</WorkToMake>
+        <WorkToBuild>3.0</WorkToBuild>
+        <MeleeWeapon_CooldownMultiplier>0.6</MeleeWeapon_CooldownMultiplier>
+      </statFactors>
+    </stuffProps>
+    <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
+
+    <modExtensions>
+
+      <li Class="RimForge.Extension">
+        <meltingPoint>2000</meltingPoint>
+      </li>
+
+      <!-- Melee weapons made from adamantium deflect bullets. Nice. -->
+      <li Class="Rimforge.StuffCompGiver">
+        <onlyMeleeWeapons>true</onlyMeleeWeapons>
+        <compClass>RimForge.Comps.CompDeflector</compClass>
+        <props Class="RimForge.Comps.CompProperties_Deflector">
+          <deflectChance>0.5</deflectChance>
+          <reflectChance>0.5</reflectChance>
+        </props>
+      </li>
+
+    </modExtensions>
+
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Resources/Bronze.xml
+++ b/1.6/Defs/Resources/Bronze.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="RF_AlloyResource">
+    <defName>RF_Bronze</defName>
+    <label>bronze</label>
+    <description>An alloy of copper and tin, has been in use since ancient times.
+Makes for very good tools, weapons and armor, at the cost of beauty and construction time.</description>
+    <graphicData>
+      <texPath>RF/Resources/Bronze</texPath>
+    </graphicData>
+    <statBases>
+      <MarketValue>6</MarketValue>
+      <Mass>0.6</Mass>
+      <StuffPower_Armor_Sharp>1.3</StuffPower_Armor_Sharp>
+      <StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
+      <StuffPower_Armor_Heat>1</StuffPower_Armor_Heat>
+      <StuffPower_Insulation_Cold>1</StuffPower_Insulation_Cold>
+      <StuffPower_Insulation_Heat>1</StuffPower_Insulation_Heat>
+      <SharpDamageMultiplier>1.3</SharpDamageMultiplier>
+      <BluntDamageMultiplier>1.3</BluntDamageMultiplier>
+    </statBases>
+    <thingCategories>
+      <li>Alloys</li>
+    </thingCategories>
+    <deepCommonality>0</deepCommonality>
+    <stuffProps>
+      <categories>
+        <li>Metallic</li>
+      </categories>
+      <commonality>0</commonality>
+      <color>(184, 106, 7)</color>
+      <statFactors>
+        <MaxHitPoints>1.4</MaxHitPoints>
+        <Beauty>0.5</Beauty>
+        <Flammability>0</Flammability>
+        <WorkToMake>1.4</WorkToMake>
+        <WorkToBuild>1.4</WorkToBuild>
+        <MeleeWeapon_CooldownMultiplier>1.1</MeleeWeapon_CooldownMultiplier>
+      </statFactors>
+      <statOffsets>
+        <Beauty>-1</Beauty>
+      </statOffsets>
+    </stuffProps>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+
+    <modExtensions>
+      <li Class="RimForge.Extension">
+        <meltingPoint>900</meltingPoint> <!-- Lower than IRL, but it's to allow simple forge setups to make bronze, in tribal colonies -->
+      </li>
+    </modExtensions>
+
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Resources/Copper.xml
+++ b/1.6/Defs/Resources/Copper.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="RF_AlloyResource">
+    <defName>RF_Copper</defName>
+    <label>copper</label>
+    <description>Pure copper. Great for alloying with other metals, but a poor material for construction or tools in this pure state.
+However, it is very malleable, making it fast to work with.</description>
+    <graphicData>
+      <texPath>RF/Resources/Copper</texPath>
+    </graphicData>
+    <statBases>
+      <MarketValue>5</MarketValue>
+      <Mass>0.6</Mass>
+      <StuffPower_Armor_Sharp>0.7</StuffPower_Armor_Sharp>
+      <StuffPower_Armor_Blunt>1</StuffPower_Armor_Blunt>
+      <StuffPower_Armor_Heat>0.3</StuffPower_Armor_Heat>
+      <StuffPower_Insulation_Cold>1</StuffPower_Insulation_Cold>
+      <StuffPower_Insulation_Heat>1</StuffPower_Insulation_Heat>
+      <SharpDamageMultiplier>0.7</SharpDamageMultiplier>
+      <BluntDamageMultiplier>1.1</BluntDamageMultiplier>
+    </statBases>
+    <thingCategories>
+      <li>ResourcesRaw</li>
+    </thingCategories>
+    <deepCommonality>1.25</deepCommonality>
+    <deepCountPerPortion>60</deepCountPerPortion>
+    <deepLumpSizeRange>30~40</deepLumpSizeRange>
+    <stuffProps>
+      <categories>
+        <li>Metallic</li>
+        <li>RF_PowerPoleMetals</li>
+      </categories>
+      <commonality>0.1</commonality>
+      <color>(212, 191, 138)</color>
+      <statFactors>
+        <MaxHitPoints>0.8</MaxHitPoints>
+        <Beauty>0.9</Beauty>
+        <Flammability>0</Flammability>
+        <WorkToMake>0.4</WorkToMake>
+        <WorkToBuild>0.5</WorkToBuild>
+        <MeleeWeapon_CooldownMultiplier>1.1</MeleeWeapon_CooldownMultiplier>
+      </statFactors>
+    </stuffProps>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+
+    <modExtensions>
+      <li Class="RimForge.Extension">
+        <meltingPoint>900</meltingPoint> <!-- A bit lower than IRL, but it's to allow simple forge setups to make bronze, in tribal colonies -->
+      </li>
+    </modExtensions>
+
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Resources/GildedPlasteel.xml
+++ b/1.6/Defs/Resources/GildedPlasteel.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="RF_AlloyResource">
+    <defName>RF_GildedPlasteel</defName>
+    <label>gilded plasteel</label>
+    <description>An alloy of plasteel and gold.
+Retains the toughness of plasteel but becomes more malleable, leading to faster construction times.
+It's also very pretty to look at.</description>
+    <graphicData>
+      <texPath>RF/Resources/GildedPlasteel</texPath>
+    </graphicData>
+    <statBases>
+      <MarketValue>12</MarketValue>
+      <Mass>0.4</Mass>
+      <StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
+      <StuffPower_Armor_Blunt>0.8</StuffPower_Armor_Blunt>
+      <StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
+      <StuffPower_Insulation_Cold>3</StuffPower_Insulation_Cold>
+      <StuffPower_Insulation_Heat>0</StuffPower_Insulation_Heat>
+      <SharpDamageMultiplier>1.15</SharpDamageMultiplier>
+      <BluntDamageMultiplier>1</BluntDamageMultiplier>
+    </statBases>
+    <thingCategories>
+      <li>Alloys</li>
+    </thingCategories>
+    <deepCommonality>0</deepCommonality>
+    <stuffProps>
+      <categories>
+        <li>Metallic</li>
+      </categories>
+      <commonality>0</commonality>
+      <color>(165, 250, 231)</color>
+      <statFactors>
+        <MaxHitPoints>2.5</MaxHitPoints>
+        <Beauty>2.2</Beauty>
+        <Flammability>0</Flammability>
+        <WorkToMake>1.5</WorkToMake>
+        <WorkToBuild>1.3</WorkToBuild>
+        <MeleeWeapon_CooldownMultiplier>0.8</MeleeWeapon_CooldownMultiplier>
+      </statFactors>
+      <statOffsets>
+        <Beauty>5</Beauty>
+      </statOffsets>
+    </stuffProps>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+
+    <modExtensions>
+      <li Class="RimForge.Extension">
+        <meltingPoint>1600</meltingPoint>
+      </li>
+    </modExtensions>
+
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Resources/GoldDore.xml
+++ b/1.6/Defs/Resources/GoldDore.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="RF_AlloyResource">
+    <defName>RF_GoldDore</defName>
+    <label>gold doré</label>
+    <description>A semi-pure alloy of gold and silver. Not very useful as a material due to it's softness, but exceedingly beautiful.</description>
+    <graphicData>
+      <texPath>RF/Resources/GoldDore</texPath>
+    </graphicData>
+    <statBases>
+      <MarketValue>26</MarketValue>
+      <Mass>0.6</Mass>
+      <StuffPower_Armor_Sharp>0.8</StuffPower_Armor_Sharp>
+      <StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
+      <StuffPower_Armor_Heat>0.4</StuffPower_Armor_Heat>
+      <StuffPower_Insulation_Cold>1</StuffPower_Insulation_Cold>
+      <StuffPower_Insulation_Heat>1</StuffPower_Insulation_Heat>
+      <SharpDamageMultiplier>0.7</SharpDamageMultiplier>
+      <BluntDamageMultiplier>1.5</BluntDamageMultiplier>
+    </statBases>
+    <thingCategories>
+      <li>Alloys</li>
+    </thingCategories>
+    <deepCommonality>0</deepCommonality>
+    <stuffProps>
+      <categories>
+        <li>Metallic</li>
+      </categories>
+      <commonality>0</commonality>
+      <color>(255,251,140)</color>
+      <statFactors>
+        <MarketValue>1.35</MarketValue>
+        <Beauty>3.0</Beauty>
+        <Flammability>0</Flammability>
+        <WorkToMake>2</WorkToMake>
+        <WorkToBuild>2</WorkToBuild>
+        <MeleeWeapon_CooldownMultiplier>1.1</MeleeWeapon_CooldownMultiplier>
+      </statFactors>
+      <statOffsets>
+        <Beauty>6</Beauty>
+      </statOffsets>
+    </stuffProps>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+
+    <modExtensions>
+      <li Class="RimForge.Extension">
+        <meltingPoint>1000</meltingPoint>
+      </li>
+    </modExtensions>
+
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Resources/Mercury.xml
+++ b/1.6/Defs/Resources/Mercury.xml
@@ -1,0 +1,35 @@
+<Defs>
+  <ThingDef ParentName="ResourceBase">
+    <defName>RF_Mercury</defName>
+    <label>mercury</label>
+    <description>Vials of liquid mercury, extracted from the Mercury Bloom plant.
+Can be refined into Mercury Ultraweave at fabrication bench by a colonist if they have the Blessing of Zir.</description>
+    <thingClass>ThingWithComps</thingClass>
+    <resourceReadoutPriority>Middle</resourceReadoutPriority>
+    <useHitPoints>false</useHitPoints>
+    <graphicData>
+      <texPath>RF/Resources/Mercury</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <thingCategories>
+      <li>ResourcesRaw</li>
+    </thingCategories>
+
+    <statBases>
+      <Mass>0.02</Mass>
+      <Flammability>0</Flammability>
+      <MarketValue>4.5</MarketValue>
+    </statBases>
+    <tradeTags>
+      <li>ExoticMisc</li>
+    </tradeTags>
+    <techLevel>Industrial</techLevel>
+    <soundInteract>Metal_Drop</soundInteract>
+    <soundDrop>Metal_Drop</soundDrop>
+    <healthAffectsPrice>false</healthAffectsPrice>
+    <tradeability>Sellable</tradeability>
+    <stackLimit>500</stackLimit>
+    <burnableByRecipe>false</burnableByRecipe>
+    <smeltable>false</smeltable>
+  </ThingDef>
+</Defs>

--- a/1.6/Defs/Resources/MercuryUltraweave.xml
+++ b/1.6/Defs/Resources/MercuryUltraweave.xml
@@ -1,0 +1,73 @@
+<Defs>
+  <ThingDef ParentName="ResourceBase">
+    <defName>RF_MercuryUltraweave</defName>
+    <label>mercury ultraweave</label>
+    <description>A cloth made out of devilstrand strengthened by mercury and plasteel.
+Highly durable and resistant to even heavy gunfire.</description>
+    <graphicData>
+      <texPath>Things/Item/Resource/Cloth</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+      <color>(220,30,120)</color>
+    </graphicData>
+
+    <costList>
+      <RF_Mercury>10</RF_Mercury>
+      <Plasteel>10</Plasteel>
+      <DevilstrandCloth>20</DevilstrandCloth>
+    </costList>
+
+    <recipeMaker>
+      <skillRequirements>
+        <RF_BlessingOfZir>0</RF_BlessingOfZir>
+      </skillRequirements>
+      <productCount>25</productCount>
+      <researchPrerequisite>RF_Research_Mercury</researchPrerequisite>   
+      <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+      <workSkill>Crafting</workSkill>
+      <effectWorking>Tailor</effectWorking>
+      <soundWorking>Recipe_Tailor</soundWorking>
+      <recipeUsers>
+        <li>ElectricTailoringBench</li>
+        <li>HandTailoringBench</li>
+      </recipeUsers>
+    </recipeMaker>
+
+    <statBases>
+      <StuffPower_Armor_Sharp>2.3</StuffPower_Armor_Sharp>
+      <StuffPower_Armor_Blunt>1.7</StuffPower_Armor_Blunt>
+      <StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
+      <StuffPower_Insulation_Cold>25</StuffPower_Insulation_Cold>
+      <StuffPower_Insulation_Heat>25</StuffPower_Insulation_Heat>
+      <MaxHitPoints>80</MaxHitPoints>
+      <MarketValue>9</MarketValue>
+      <Mass>0.03</Mass>
+      <Flammability>0.1</Flammability>
+      <DeteriorationRate>0.25</DeteriorationRate>
+    </statBases>
+    <burnableByRecipe>true</burnableByRecipe>
+    <healthAffectsPrice>false</healthAffectsPrice>
+    <minRewardCount>30</minRewardCount>
+    <stuffProps>
+
+      <statFactors>
+        <Flammability>0.4</Flammability>
+        <Beauty>3</Beauty>
+        <MaxHitPoints>3</MaxHitPoints>
+      </statFactors>
+
+      <categories>
+        <li>Fabric</li>
+      </categories>
+      <color>(220,30,120)</color>
+      <commonality>0.1</commonality>
+    </stuffProps>
+    <thingCategories>
+      <li>Textiles</li>
+    </thingCategories>
+    <comps>
+      <li>
+        <compClass>CompColorable</compClass>
+      </li>
+    </comps>
+  </ThingDef>
+</Defs>

--- a/1.6/Defs/Resources/ResourceBase.xml
+++ b/1.6/Defs/Resources/ResourceBase.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef Name="RF_AlloyResource" ParentName="ResourceBase" Abstract="True">
+    <soundInteract>Metal_Drop</soundInteract>
+    <soundDrop>Metal_Drop</soundDrop>
+    <useHitPoints>false</useHitPoints>
+    <healthAffectsPrice>false</healthAffectsPrice>
+    <tradeability>Sellable</tradeability>
+    <stackLimit>200</stackLimit>
+    <burnableByRecipe>false</burnableByRecipe>
+    <smeltable>true</smeltable>
+    <graphicData>
+      <texPath>RF/Resources/Copper</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <stuffProps>
+      <constructEffect>ConstructMetal</constructEffect>
+      <soundImpactMelee>BulletImpact_Metal</soundImpactMelee>
+      <soundMeleeHitSharp>MeleeHit_Metal_Sharp</soundMeleeHitSharp>
+      <soundMeleeHitBlunt>MeleeHit_Metal_Blunt</soundMeleeHitBlunt>
+    </stuffProps>
+    <comps>
+      <li Class="RimForge.Comps.CompProperties_ShowAlloyInfo"></li>
+    </comps>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Resources/Staballoy.xml
+++ b/1.6/Defs/Resources/Staballoy.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="RF_AlloyResource">
+    <defName>RF_Staballoy</defName>
+    <label>staballoy</label>
+    <description>An alloy of uranium and plasteel.
+Incredibly dense and resitant to blunt and sharp damage, but very ugly to look at.
+It's strength allows to to be forged into wickedly sharp bladed weapons, but the wielder may find the weight overwhelming.</description>
+    <graphicData>
+      <texPath>RF/Resources/Staballoy</texPath>
+    </graphicData>
+    <statBases>
+      <MarketValue>16</MarketValue>
+      <Mass>1</Mass>
+      <StuffPower_Armor_Sharp>1.8</StuffPower_Armor_Sharp>
+      <StuffPower_Armor_Blunt>2</StuffPower_Armor_Blunt>
+      <StuffPower_Armor_Heat>1.3</StuffPower_Armor_Heat>
+      <StuffPower_Insulation_Cold>4</StuffPower_Insulation_Cold>
+      <StuffPower_Insulation_Heat>1</StuffPower_Insulation_Heat>
+      <SharpDamageMultiplier>1.7</SharpDamageMultiplier>
+      <BluntDamageMultiplier>1.5</BluntDamageMultiplier>
+    </statBases>
+    <thingCategories>
+      <li>Alloys</li>
+    </thingCategories>
+    <deepCommonality>0</deepCommonality>
+    <stuffProps>
+      <categories>
+        <li>Metallic</li>
+      </categories>
+      <commonality>0</commonality>
+      <color>(53, 110, 47)</color>
+      <statFactors>
+        <MaxHitPoints>4.5</MaxHitPoints>
+        <Beauty>0.25</Beauty>
+        <Flammability>0</Flammability>
+        <WorkToMake>2.25</WorkToMake>
+        <WorkToBuild>2.5</WorkToBuild>
+        <MeleeWeapon_CooldownMultiplier>1.5</MeleeWeapon_CooldownMultiplier>
+      </statFactors>
+      <statOffsets>
+        <Beauty>-15</Beauty>
+      </statOffsets>
+    </stuffProps>
+    <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
+
+    <modExtensions>
+      <li Class="RimForge.Extension">
+        <meltingPoint>1800</meltingPoint>
+      </li>
+    </modExtensions>
+
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Resources/Tin.xml
+++ b/1.6/Defs/Resources/Tin.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="RF_AlloyResource">
+    <defName>RF_Tin</defName>
+    <label>tin</label>
+    <description>Pure tin. Essential for the production of bronze and other alloys.
+In this pure state, it is a very soft metal, and so is not well suited for weapons, tools or armor.</description>
+    <graphicData>
+      <texPath>RF/Resources/Tin</texPath>
+    </graphicData>
+    <statBases>
+      <MarketValue>5</MarketValue>
+      <Mass>0.6</Mass>
+      <StuffPower_Armor_Sharp>0.4</StuffPower_Armor_Sharp>
+      <StuffPower_Armor_Blunt>0.7</StuffPower_Armor_Blunt>
+      <StuffPower_Armor_Heat>0.9</StuffPower_Armor_Heat>
+      <StuffPower_Insulation_Cold>1</StuffPower_Insulation_Cold>
+      <StuffPower_Insulation_Heat>1</StuffPower_Insulation_Heat>
+      <SharpDamageMultiplier>0.6</SharpDamageMultiplier>
+      <BluntDamageMultiplier>1.1</BluntDamageMultiplier>
+    </statBases>
+    <thingCategories>
+      <li>ResourcesRaw</li>
+    </thingCategories>
+    <deepCommonality>1.25</deepCommonality>
+    <deepCountPerPortion>70</deepCountPerPortion>
+    <deepLumpSizeRange>40~45</deepLumpSizeRange>
+    <stuffProps>
+      <categories>
+        <li>Metallic</li>
+        <li>RF_PowerPoleMetals</li>
+      </categories>
+      <commonality>0.25</commonality>
+      <statFactors>
+        <MaxHitPoints>0.5</MaxHitPoints>
+        <Beauty>0.6</Beauty>
+        <Flammability>0.2</Flammability>
+        <WorkToMake>0.8</WorkToMake>
+        <WorkToBuild>0.8</WorkToBuild>
+      </statFactors>
+    </stuffProps>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+
+    <modExtensions>
+      <li Class="RimForge.Extension">
+        <meltingPoint>230</meltingPoint> <!-- A bit lower than IRL, but it's to allow simple forge setups to make bronze, in tribal colonies -->
+      </li>
+    </modExtensions>
+
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Sounds/Sounds.xml
+++ b/1.6/Defs/Sounds/Sounds.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <SoundDef>
+    <defName>RF_Sound_CoilgunFire</defName>
+    <sustain>true</sustain>
+    <context>MapOnly</context>
+    <maxSimultaneous>8</maxSimultaneous>
+    <priorityMode>PrioritizeNearest</priorityMode>
+    <subSounds>
+      <li>
+        <onCamera>true</onCamera>
+        <tempoAffectedByGameSpeed>true</tempoAffectedByGameSpeed>
+        <grains>
+          <li Class="AudioGrain_Clip">
+            <clipPath>RF/CoilgunFire</clipPath>
+          </li>
+        </grains>
+        <sustainLoop>false</sustainLoop>
+        <volumeRange>40~40</volumeRange>
+        <pitchRange>1~1</pitchRange>
+      </li>
+    </subSounds>
+  </SoundDef>
+
+  <SoundDef>
+    <defName>RF_Sound_DroneLaunch</defName>
+    <sustain>false</sustain>
+    <context>MapOnly</context>
+    <maxSimultaneous>8</maxSimultaneous>
+    <priorityMode>PrioritizeNearest</priorityMode>
+    <subSounds>
+      <li>
+        <onCamera>false</onCamera>
+        <tempoAffectedByGameSpeed>true</tempoAffectedByGameSpeed>
+        <grains>
+          <li Class="AudioGrain_Clip">
+            <clipPath>RF/DroneLaunch</clipPath>
+          </li>
+        </grains>
+        <sustainLoop>false</sustainLoop>
+        <volumeRange>100~100</volumeRange>
+        <pitchRange>0.95~1.05</pitchRange>
+      </li>
+    </subSounds>
+  </SoundDef>
+
+  <SoundDef>
+    <defName>RF_Sound_Drone</defName>
+    <sustain>false</sustain>
+    <context>MapOnly</context>
+    <maxSimultaneous>8</maxSimultaneous>
+    <subSounds>
+      <li>
+        <onCamera>true</onCamera>
+        <tempoAffectedByGameSpeed>true</tempoAffectedByGameSpeed>
+        <grains>
+          <li Class="AudioGrain_Clip">
+            <clipPath>RF/Drone</clipPath>
+          </li>
+        </grains>
+        <sustainLoop>false</sustainLoop>
+        <volumeRange>70~70</volumeRange>
+        <pitchRange>1~1</pitchRange>
+      </li>
+    </subSounds>
+  </SoundDef>
+
+</Defs>

--- a/1.6/Defs/ThoughtDefs/OtherThoughts.xml
+++ b/1.6/Defs/ThoughtDefs/OtherThoughts.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThoughtDef>
+    <defName>RF_WaveOfHate</defName>
+    <durationDays>0.5</durationDays>
+    <stackLimit>1</stackLimit>
+    <stages>
+      <li>
+        <label>wave of hate</label>
+        <description>A wave of darkness and hate washed over me.\n\n(Caused by the nearby death of a pawn suffering from Zir's Corruption)</description>
+        <baseMoodEffect>-30</baseMoodEffect>
+      </li>
+    </stages>
+  </ThoughtDef>
+
+  <ThoughtDef>
+    <defName>RF_Corrupted</defName>
+    <workerClass>RimForge.Thoughts.ThoughtWorker_Corrupted</workerClass>
+    <stages>
+      <li>
+        <label>Zir's corruption</label>
+        <description>This person's mind has been broken by an obsession or hatred towards the deity Zir and it's followers.</description>
+        <baseMoodEffect>-50</baseMoodEffect>
+      </li>
+    </stages>
+  </ThoughtDef>
+
+  <ThoughtDef>
+    <defName>RF_ZirKiller</defName>
+    <durationDays>1</durationDays>
+    <stackLimit>1</stackLimit>
+    <stages>
+      <li>
+        <label>attacking Zir's followers</label>
+        <description>Finally, I have the chance to kill the heretical followers of Zir!</description>
+        <baseMoodEffect>75</baseMoodEffect>
+      </li>
+    </stages>
+  </ThoughtDef>
+
+</Defs>

--- a/1.6/Defs/ThoughtDefs/RitualThoughts.xml
+++ b/1.6/Defs/ThoughtDefs/RitualThoughts.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThoughtDef>
+    <defName>RF_RitualBlessed</defName>
+    <durationDays>2</durationDays>
+    <stages>
+      <li>
+        <label>blessed by zir</label>
+        <description>I've just been blessed by Zir. I can see a whole new world of possibility.</description>
+        <baseMoodEffect>8</baseMoodEffect>
+      </li>
+    </stages>
+  </ThoughtDef>
+
+  <ThoughtDef>
+    <defName>RF_RitualBadThought</defName>
+    <durationDays>2</durationDays>
+    <stackLimit>3</stackLimit>
+    <nullifyingTraits>
+      <li>Psychopath</li>
+      <li>Bloodlust</li>
+    </nullifyingTraits>
+    <stages>
+      <li>
+        <label>sacrificed prisoner</label>
+        <description>One of our prisoners was sacrificed to Machine God Zir.
+We gained the blessing, but somebody in our care had to die for it...</description>
+        <baseMoodEffect>-4</baseMoodEffect>
+      </li>
+      <li>
+        <label>sacrificed prisoner</label>
+        <description>One of our prisoners was sacrificed to Machine God Zir.
+The prisoner was guilty, but it still doesn't feel right...</description>
+        <baseMoodEffect>-2</baseMoodEffect>
+      </li>
+    </stages>
+  </ThoughtDef>
+
+</Defs>

--- a/1.6/Defs/ThoughtDefs/WeaponThoughts.xml
+++ b/1.6/Defs/ThoughtDefs/WeaponThoughts.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThoughtDef>
+    <defName>RF_WeaponThought</defName>
+    <workerClass>RimForge.Thoughts.ThoughtWorker_SpecialWeapon</workerClass>
+    <stages>
+
+      <!-- Regular pawn carrying blessed weapon -->
+      <li>
+        <label>blessed weapon</label>
+        <description>The weapon I'm carring radiates warmth and fills me with positive feelings. </description>
+        <baseMoodEffect>8</baseMoodEffect>
+      </li>
+
+      <!-- Blessed pawn carrying blessed weapon -->
+      <li>
+        <label>blessed weapon</label>
+        <description>The weapon I'm carring radiates warmth and fills me with positive feelings.\nI feel that this weapon symbolizes my link with the great Machine God Zir.</description>
+        <baseMoodEffect>16</baseMoodEffect>
+      </li>
+
+      <!-- Regular pawn carrying cursed weapon -->
+      <li>
+        <label>cursed weapon</label>
+        <description>The weapon I'm carrying radiates waves of evil and makes me think awful thoughts. I don't want to hold this cursed weapon for a second longer.</description>
+        <baseMoodEffect>-25</baseMoodEffect>
+      </li>
+    </stages>
+  </ThoughtDef>
+
+</Defs>

--- a/1.6/Defs/Traits/BlessingOfZir.xml
+++ b/1.6/Defs/Traits/BlessingOfZir.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <TraitDef>
+    <defName>RF_BlessingOfZir</defName>
+    <commonality>0.05</commonality>
+    <degreeDatas>
+      <li>
+        <label>blessing of Zir</label>
+        <description>[PAWN_nameDef] has received the blessing of machine god Zir!
+[PAWN_nameDef] is able to easily understand the inner workings of machines and devices, allowing [PAWN_objective] to craft and build items of higher quality as well as work faster.</description>
+        <statFactors>
+          <GeneralLaborSpeed>1.25</GeneralLaborSpeed>
+          <SmeltingSpeed>1.5</SmeltingSpeed>
+          <ConstructionSpeed>1.25</ConstructionSpeed>
+          <ButcheryMechanoidSpeed>2</ButcheryMechanoidSpeed>
+        </statFactors>
+        <statOffsets>
+          <ButcheryMechanoidEfficiency>0.5</ButcheryMechanoidEfficiency>
+          <ConstructSuccessChance>1</ConstructSuccessChance>
+        </statOffsets>
+      </li>
+    </degreeDatas>
+    <conflictingTraits>
+      <li>RF_ZirsCorruption</li>
+    </conflictingTraits>
+  </TraitDef>
+
+</Defs>

--- a/1.6/Defs/Traits/ZirsCorruption.xml
+++ b/1.6/Defs/Traits/ZirsCorruption.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <TraitDef>
+    <defName>RF_ZirsCorruption</defName>
+    <commonality>0.05</commonality>
+    <degreeDatas>
+      <li>
+        <label>Zir's Corruption</label>
+        <description>[PAWN_nameDef]'s mind has been twisted by Zir!
+An obsession or hatred revolving around Machine God Zir has lead this individual to madness, but also unlocked previously unknown physical prowess.</description>
+        <statFactors>
+          <GeneralLaborSpeed>0.25</GeneralLaborSpeed>
+          <MoveSpeed>3</MoveSpeed>
+          <MentalBreakThreshold>4</MentalBreakThreshold>
+          <MeleeHitChance>1.5</MeleeHitChance>
+        </statFactors>
+      </li>
+    </degreeDatas>
+    <conflictingTraits>
+      <li>RF_BlessingOfZir</li>
+    </conflictingTraits>
+  </TraitDef>
+
+</Defs>

--- a/1.6/Defs/Weapons/CursedKhopesh.xml
+++ b/1.6/Defs/Weapons/CursedKhopesh.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BaseWeapon">
+    <defName>RF_CursedKhopesh</defName>
+    <label>cursed khopesh</label>
+    <description>A cursed weapon, it's great power comes from the corrupted mind of it's wielder.
+
+People who's mind has not be corrupted by Zir will feel terrible if they equip this weapon.</description>
+
+    <techLevel>Medieval</techLevel>
+    <smeltable>false</smeltable>
+    <burnableByRecipe>true</burnableByRecipe>
+    <tradeability>Sellable</tradeability>
+    <thingCategories>
+      <li>WeaponsMelee</li>
+    </thingCategories>
+
+    <graphicData>
+      <texPath>RF/Weapons/CursedKhopesh</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.3,1.3)</drawSize>
+    </graphicData>
+    <statBases>
+      <MarketValue>5000</MarketValue>
+      <MaxHitPoints>300</MaxHitPoints>
+      <Mass>5</Mass>
+    </statBases>
+
+    <equippedStatOffsets>
+      <MoveSpeed>0.4</MoveSpeed> <!-- Gives +0.5 cps movement boost. Because I can. -->
+    </equippedStatOffsets>    
+    <equippedAngleOffset>-40</equippedAngleOffset>
+    <tools>
+      <li>
+        <label>blade</label>
+        <capacities>
+          <li>Cut</li>
+        </capacities>
+        <power>20</power>
+        <armorPenetration>0.8</armorPenetration>
+        <cooldownTime>1.1</cooldownTime>
+      </li>
+    </tools>
+    <comps>
+      <li Class="RimForge.Comps.CompProperties_OversizedWeapon"></li>
+    </comps>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Weapons/GaeBulg.xml
+++ b/1.6/Defs/Weapons/GaeBulg.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BaseMeleeWeapon_Sharp_Quality">
+    <defName>RF_GaeBulg</defName>
+    <label>gáe bulg</label>
+    <description>A red spear-like weapon, as heavy as it is lethal.
+It has more spikey bits to make it easier to poke people with.</description>
+    <graphicData>
+      <texPath>RF/Weapons/GaeBulg</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.65,1.65)</drawSize>
+    </graphicData>
+
+    <costList>
+      <ComponentIndustrial>4</ComponentIndustrial>
+      <RF_Staballoy>40</RF_Staballoy>
+    </costList>
+
+    <techLevel>Medieval</techLevel>
+    <thingSetMakerTags>
+      <li>RewardStandardQualitySuper</li>
+    </thingSetMakerTags>
+    <statBases>
+      <MaxHitPoints>300</MaxHitPoints>
+      <WorkToMake>19000</WorkToMake>
+      <Mass>5</Mass>
+    </statBases>
+    <equippedStatOffsets>
+      <MoveSpeed>0.1</MoveSpeed> <!-- Gives +0.1 cps movement boost. Because I can. -->
+    </equippedStatOffsets>    
+    <equippedAngleOffset>20</equippedAngleOffset>
+    <recipeMaker>
+      <researchPrerequisite>LongBlades</researchPrerequisite>
+      <skillRequirements>
+        <Crafting>5</Crafting>
+      </skillRequirements>
+    </recipeMaker>
+    <tools>
+      <li>
+        <label>point</label>
+        <capacities>
+          <li>Stab</li>
+        </capacities>
+        <power>25</power>
+        <armorPenetration>0.6</armorPenetration>
+        <cooldownTime>1.5</cooldownTime>
+      </li>
+    </tools>
+    <comps>
+      <li Class="RimForge.Comps.CompProperties_OversizedWeapon"></li>
+    </comps>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Weapons/Khopesh.xml
+++ b/1.6/Defs/Weapons/Khopesh.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BaseMeleeWeapon_Sharp_Quality">
+    <defName>RF_Khopesh</defName>
+    <label>khopesh</label>
+    <description>The khopesh saw an increase in popularity after humans left Old Earth.
+It was sought after as an ornamental sidearm, and quickly gained popularity across many colony worlds.</description>
+    <techLevel>Medieval</techLevel>
+    <smeltable>true</smeltable>
+    <burnableByRecipe>true</burnableByRecipe>
+    <tradeability>All</tradeability>
+
+    <graphicData>
+      <texPath>RF/Weapons/Khopesh</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.3,1.3)</drawSize>
+    </graphicData>
+    <statBases>
+      <WorkToMake>6000</WorkToMake>
+      <MarketValue>600</MarketValue>
+      <MaxHitPoints>100</MaxHitPoints>
+      <Mass>4</Mass>
+    </statBases>
+
+    <recipeMaker>
+      <researchPrerequisite>LongBlades</researchPrerequisite>
+    </recipeMaker>
+    <costList>
+      <WoodLog>20</WoodLog>
+      <Steel>60</Steel>
+    </costList>
+
+    <equippedStatOffsets>
+      <MoveSpeed>0.4</MoveSpeed> <!-- Gives +0.5 cps movement boost. Because I can. -->
+    </equippedStatOffsets>    
+    <equippedAngleOffset>-40</equippedAngleOffset>
+    <tools>
+      <li>
+        <label>blade</label>
+        <capacities>
+          <li>Cut</li>
+        </capacities>
+        <power>15</power>
+        <armorPenetration>0.5</armorPenetration>
+        <cooldownTime>1.1</cooldownTime>
+      </li>
+    </tools>
+    <comps>
+      <li Class="RimForge.Comps.CompProperties_OversizedWeapon"></li>
+    </comps>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Weapons/StablePistol.xml
+++ b/1.6/Defs/Weapons/StablePistol.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <!-- Gun -->
+  <ThingDef ParentName="BaseHumanMakeableGun">
+    <defName>RF_StablePistol</defName>
+    <label>stable pistol</label>
+    <techLevel>Industrial</techLevel>
+    <description>An advanced military pistol with excellent accuracy, range and rate of fire, but very poor damage.
+Made using metal alloys.</description>
+    <graphicData>
+      <texPath>RF/Weapons/StablePistol</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <statBases>
+      <WorkToMake>9000</WorkToMake>
+      <Mass>2.0</Mass>
+      <AccuracyTouch>0.9</AccuracyTouch>
+      <AccuracyShort>0.95</AccuracyShort>
+      <AccuracyMedium>0.8</AccuracyMedium>
+      <AccuracyLong>0.75</AccuracyLong>
+      <RangedWeapon_Cooldown>0.2</RangedWeapon_Cooldown>
+      <MarketValue>2300</MarketValue>
+    </statBases>
+    <thingSetMakerTags><li>RewardStandardQualitySuper</li></thingSetMakerTags>
+    <soundInteract>Interact_Rifle</soundInteract>
+    <costList>
+      <Plasteel>10</Plasteel>
+      <ComponentIndustrial>4</ComponentIndustrial>
+      <RF_Bronze>25</RF_Bronze>
+    </costList>
+    <recipeMaker>
+      <skillRequirements>
+        <Crafting>6</Crafting>
+      </skillRequirements>
+    </recipeMaker>
+    <weaponTags>
+      <li>IndustrialGunAdvanced</li>
+    </weaponTags>
+    <verbs>
+      <li>
+        <verbClass>Verb_Shoot</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>RF_Bullet_StablePistol</defaultProjectile>
+        <warmupTime>0.25</warmupTime>
+        <range>34.5</range>
+        <burstShotCount>1</burstShotCount>
+        <soundCast>RF_Sound_StableRifleShot</soundCast>
+        <soundCastTail>GunTail_Medium</soundCastTail>
+        <muzzleFlashScale>10</muzzleFlashScale>
+      </li>
+    </verbs>
+    <tools>
+      <li>
+        <label>stock</label>
+        <capacities>
+          <li>Blunt</li>
+        </capacities>
+        <power>5</power>
+        <cooldownTime>2</cooldownTime>
+      </li>
+      <li>
+        <label>barrel</label>
+        <capacities>
+          <li>Blunt</li>
+          <li>Poke</li>
+        </capacities>
+        <power>5</power>
+        <cooldownTime>2</cooldownTime>
+      </li>
+    </tools>
+  </ThingDef>
+
+  <!-- Bullet -->
+  <ThingDef ParentName="BaseBullet">
+    <defName>RF_Bullet_StablePistol</defName>
+    <label>stable pistol bullet</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile>
+      <damageDef>Bullet</damageDef>
+      <damageAmountBase>5</damageAmountBase>
+      <stoppingPower>0.5</stoppingPower>
+      <speed>120</speed>
+    </projectile>
+  </ThingDef>
+
+
+</Defs>

--- a/1.6/Defs/Weapons/StableRifle.xml
+++ b/1.6/Defs/Weapons/StableRifle.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <!-- Gun -->
+  <ThingDef ParentName="BaseHumanMakeableGun">
+    <defName>RF_StableRifle</defName>
+    <label>stable rifle</label>
+    <techLevel>Industrial</techLevel>
+    <description>An advanced military rifle with excellent accuracy, range and stability, but very poor damage.
+Made using metal alloys.</description>
+    <graphicData>
+      <texPath>RF/Weapons/StableRifle</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <statBases>
+      <WorkToMake>12000</WorkToMake>
+      <Mass>3.8</Mass>
+      <AccuracyTouch>0.8</AccuracyTouch>
+      <AccuracyShort>0.95</AccuracyShort>
+      <AccuracyMedium>0.9</AccuracyMedium>
+      <AccuracyLong>0.85</AccuracyLong>
+      <RangedWeapon_Cooldown>0.7</RangedWeapon_Cooldown>
+      <MarketValue>2700</MarketValue>
+    </statBases>
+    <thingSetMakerTags><li>RewardStandardQualitySuper</li></thingSetMakerTags>
+    <soundInteract>Interact_Rifle</soundInteract>
+    <costList>
+      <Plasteel>20</Plasteel>
+      <ComponentIndustrial>7</ComponentIndustrial>
+      <RF_Bronze>50</RF_Bronze>
+    </costList>
+    <recipeMaker>
+      <skillRequirements>
+        <Crafting>7</Crafting>
+      </skillRequirements>
+    </recipeMaker>
+    <weaponTags>
+      <li>IndustrialGunAdvanced</li>
+    </weaponTags>
+    <equippedAngleOffset>30.3</equippedAngleOffset>
+    <verbs>
+      <li>
+        <verbClass>Verb_Shoot</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>RF_Bullet_StableRifle</defaultProjectile>
+        <warmupTime>0.4</warmupTime>
+        <range>36.5</range>
+        <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+        <burstShotCount>5</burstShotCount>
+        <soundCast>RF_Sound_StableRifleShot</soundCast>
+        <soundCastTail>GunTail_Medium</soundCastTail>
+        <muzzleFlashScale>12</muzzleFlashScale>
+      </li>
+    </verbs>
+    <tools>
+      <li>
+        <label>stock</label>
+        <capacities>
+          <li>Blunt</li>
+        </capacities>
+        <power>9</power>
+        <cooldownTime>2</cooldownTime>
+      </li>
+      <li>
+        <label>barrel</label>
+        <capacities>
+          <li>Blunt</li>
+          <li>Poke</li>
+        </capacities>
+        <power>9</power>
+        <cooldownTime>2</cooldownTime>
+      </li>
+    </tools>
+  </ThingDef>
+
+  <!-- Bullet -->
+  <ThingDef ParentName="BaseBullet">
+    <defName>RF_Bullet_StableRifle</defName>
+    <label>stable rifle bullet</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile>
+      <damageDef>Bullet</damageDef>
+      <damageAmountBase>6</damageAmountBase>
+      <stoppingPower>0.5</stoppingPower>
+      <speed>140</speed>
+    </projectile>
+  </ThingDef>
+
+  <!-- Shot sound -->
+  <SoundDef>
+    <defName>RF_Sound_StableRifleShot</defName>
+    <context>MapOnly</context>
+    <maxSimultaneous>16</maxSimultaneous>
+    <subSounds>
+      <li>
+        <grains>
+          <li Class="AudioGrain_Clip">
+            <clipPath>RF/StableRifleFire</clipPath>
+          </li>
+        </grains>
+        <pitchRange>0.96~1.04</pitchRange>
+      </li>
+    </subSounds>
+  </SoundDef>
+
+</Defs>

--- a/1.6/Defs/Weapons/SwordOfDarkness.xml
+++ b/1.6/Defs/Weapons/SwordOfDarkness.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BaseWeapon">
+    <defName>RF_SwordOfDarkness</defName>
+    <label>Ea, Sword of Darkness</label>
+    <description>A cursed weapon, it's great power comes from the corrupted mind of it's wielder.
+Can be reforged into 'Sen, Sword of Rapture' at a smithing table.
+
+People who's mind has not be corrupted by Zir will feel terrible if they equip this weapon.</description>
+
+    <techLevel>Spacer</techLevel>
+    <smeltable>false</smeltable>
+    <burnableByRecipe>true</burnableByRecipe>
+    <tradeability>Sellable</tradeability>
+    <thingCategories>
+      <li>WeaponsMelee</li>
+    </thingCategories>
+
+    <graphicData>
+      <texPath>RF/Weapons/SwordOfDarkness</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.35,1.35)</drawSize>
+    </graphicData>
+    <statBases>
+      <MarketValue>6000</MarketValue>
+      <MaxHitPoints>300</MaxHitPoints>
+      <Mass>5</Mass>
+    </statBases>
+
+    <equippedStatOffsets>
+      <MoveSpeed>0.5</MoveSpeed> <!-- Gives +0.5 cps movement boost. Because I can. -->
+    </equippedStatOffsets>    
+    <equippedAngleOffset>-40</equippedAngleOffset>
+    <tools>
+      <li>
+        <label>blade</label>
+        <capacities>
+          <li>Blunt</li>
+        </capacities>
+        <power>50</power>
+        <armorPenetration>1.4</armorPenetration>
+        <cooldownTime>1.1</cooldownTime>
+      </li>
+    </tools>
+    <comps>
+      <li Class="RimForge.Comps.CompProperties_OversizedWeapon"></li>
+    </comps>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Weapons/SwordOfRapture.xml
+++ b/1.6/Defs/Weapons/SwordOfRapture.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BaseMeleeWeapon_Blunt_Quality">
+    <defName>RF_SwordOfRapture</defName>
+    <label>Sen, Sword of Rapture</label>
+    <description>A purified and restored version of Ea, Sword of Darkness.
+Despite it's designation as a sword, it's blade is actually blunt, dealing heavy crushing blows.
+
+People who hold this weapon feel it's warmth radiating through them, increased effect if they have the Blessing of Zir.</description>
+    <graphicData>
+      <texPath>RF/Weapons/SwordOfRapture</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.35,1.45)</drawSize>
+    </graphicData>
+    <tradeability>Sellable</tradeability>
+    <techLevel>Spacer</techLevel>
+    <thingSetMakerTags>
+      <li>RewardStandardQualitySuper</li>
+    </thingSetMakerTags>
+    <statBases>
+      <MaxHitPoints>300</MaxHitPoints>
+      <WorkToMake>24000</WorkToMake>
+      <Mass>5</Mass>
+    </statBases>
+
+    <costList>
+      <RF_SwordOfDarkness>1</RF_SwordOfDarkness>
+      <RF_Staballoy>40</RF_Staballoy>
+      <ComponentSpacer>4</ComponentSpacer>
+    </costList>
+    <recipeMaker>
+      <researchPrerequisite>RF_Research_Ritual</researchPrerequisite>
+      <skillRequirements>
+        <RF_BlessingOfZir>0</RF_BlessingOfZir>
+        <Crafting>10</Crafting>
+      </skillRequirements>
+    </recipeMaker>
+
+    <equippedStatOffsets>
+      <MoveSpeed>0.4</MoveSpeed> <!-- Gives +0.5 cps movement boost. Because I can. -->
+    </equippedStatOffsets>    
+    <equippedAngleOffset>-40</equippedAngleOffset>
+    <tools>
+      <li>
+        <label>blade</label>
+        <capacities>
+          <li>Blunt</li>
+        </capacities>
+        <power>35</power>
+        <armorPenetration>1.5</armorPenetration>
+        <cooldownTime>1.1</cooldownTime>
+      </li>
+    </tools>
+    <comps>
+      <li Class="RimForge.Comps.CompProperties_OversizedWeapon"></li>
+    </comps>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/Weapons/VirtuousTreaty.xml
+++ b/1.6/Defs/Weapons/VirtuousTreaty.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ThingDef ParentName="BaseMeleeWeapon_Sharp">
+    <defName>RF_VirtuousTreaty</defName>
+    <label>Virtuous Treaty</label>
+    <description>A huge longsword with a strange offset blade. Deals huge damage with high armor penetration.
+Has a 75% chance to deflect bullets back at the attacker.
+
+Memories from another time stir within its pearly blade.</description>
+    <graphicData>
+      <texPath>RF/Weapons/VirtuousTreaty</texPath>
+      <shaderType>CutoutComplex</shaderType>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.8,1.8)</drawSize>
+    </graphicData>
+
+    <costList>
+      <ComponentIndustrial>12</ComponentIndustrial>
+      <ComponentSpacer>2</ComponentSpacer>
+      <RF_GildedPlasteel>50</RF_GildedPlasteel>
+    </costList>
+    <costStuffCount>100</costStuffCount>
+    <stuffCategories>
+      <li>Metallic</li>
+    </stuffCategories>
+
+    <techLevel>Spacer</techLevel>
+    <weaponTags>
+      <li>SpacerMeleeAdvanced</li>
+    </weaponTags>
+    <thingSetMakerTags>
+      <li>RewardStandardQualitySuper</li>
+    </thingSetMakerTags>
+    <statBases>
+      <MarketValue>3500</MarketValue>
+      <MaxHitPoints>500</MaxHitPoints>
+      <WorkToMake>22000</WorkToMake>
+      <Mass>8</Mass>
+    </statBases>
+    <equippedStatOffsets>
+      <MoveSpeed>0.25</MoveSpeed> <!-- Gives +0.25 cps movement boost. Because I can. -->
+    </equippedStatOffsets>
+    <equippedAngleOffset>-45</equippedAngleOffset>
+    <recipeMaker>
+      <researchPrerequisite>LongBlades</researchPrerequisite>
+      <skillRequirements>
+        <Crafting>8</Crafting>
+      </skillRequirements>
+    </recipeMaker>
+    <tools>
+      <li>
+        <label>point</label>
+        <capacities>
+          <li>Stab</li>
+        </capacities>
+        <power>30</power>
+        <armorPenetration>1.1</armorPenetration>
+        <cooldownTime>2</cooldownTime>
+      </li>
+      <li>
+        <label>edge</label>
+        <capacities>
+          <li>Cut</li>
+        </capacities>
+        <power>35</power>
+        <armorPenetration>0.9</armorPenetration>
+        <cooldownTime>2.25</cooldownTime>
+      </li>
+    </tools>
+    <comps>
+      <li Class="RimForge.Comps.CompProperties_OversizedWeapon">
+        <southOffset>(0.4, 0, 0.3)</southOffset>
+        <northOffset>(0.4, 0, 0.3)</northOffset>
+        <eastOffset>(0.3, 0, 0.38)</eastOffset>
+        <westOffset>(-0.3, 0, 0.38)</westOffset>
+      </li>
+      <li Class="RimForge.Comps.CompProperties_Deflector">
+        <deflectChance>0.75</deflectChance>
+        <reflectChance>1</reflectChance>
+      </li>
+    </comps>
+  </ThingDef>
+
+</Defs>

--- a/1.6/Defs/WorkgiverDefs/WorkGiver_Forge.xml
+++ b/1.6/Defs/WorkgiverDefs/WorkGiver_Forge.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <WorkGiverDef>
+    <defName>RF_DoForgeWork</defName>
+    <giverClass>WorkGiver_DoBill</giverClass>
+    <workType>Smithing</workType>
+    <priorityInType>96</priorityInType>
+    <verb>forge</verb>
+    <gerund>forging at</gerund>
+    <fixedBillGiverDefs>
+      <li>RF_Forge</li>
+    </fixedBillGiverDefs>
+    <requiredCapacities>
+      <li>Manipulation</li>
+    </requiredCapacities>
+    <prioritizeSustains>true</prioritizeSustains>
+  </WorkGiverDef>
+
+</Defs>

--- a/1.6/Patches/LongRangeScannerPatch.xml
+++ b/1.6/Patches/LongRangeScannerPatch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/GenStepDef[defName="PreciousLump"]/genStep/mineables</xpath>
+    <value>
+      <li>RF_MineableCopper</li>
+      <li>RF_MineableTin</li>
+    </value>
+  </Operation>
+
+</Patch>

--- a/1.6/Patches/MetalsExpanded.xml
+++ b/1.6/Patches/MetalsExpanded.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Expanded Materials - Metals</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <success>Always</success>
+      <operations>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/ThingDef[defName="VMEu_Copper"]</xpath>
+          <value>
+            <li Class="RimForge.Extension">
+              <equivalentTo>RF_Copper</equivalentTo>
+            </li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="VMEu_Copper"]/stuffProps/categories</xpath>
+          <value>
+            <li>RF_PowerPoleMetals</li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/ThingDef[defName="VMEu_Tin"]</xpath>
+          <value>
+            <li Class="RimForge.Extension">
+              <equivalentTo>RF_Tin</equivalentTo>
+            </li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="VMEu_Tin"]/stuffProps/categories</xpath>
+          <value>
+            <li>RF_PowerPoleMetals</li>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/1.6/Patches/RimFactoryRevivedMaterials.xml
+++ b/1.6/Patches/RimFactoryRevivedMaterials.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Project RimFactory - Materials</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <success>Always</success>
+      <operations>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/ThingDef[defName="PRF_Copper"]</xpath>
+          <value>
+            <li Class="RimForge.Extension">
+              <equivalentTo>RF_Copper</equivalentTo>
+            </li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="PRF_Copper"]/stuffProps/categories</xpath>
+          <value>
+            <li>RF_PowerPoleMetals</li>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/1.6/Patches/VanillaResourcePatches.xml
+++ b/1.6/Patches/VanillaResourcePatches.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gold"]</xpath>
+    <value>
+      <li Class="RimForge.Extension">
+        <meltingPoint>1000</meltingPoint>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Silver"]</xpath>
+    <value>
+      <li Class="RimForge.Extension">
+        <meltingPoint>950</meltingPoint>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Steel"]</xpath>
+    <value>
+      <li Class="RimForge.Extension">
+        <meltingPoint>1400</meltingPoint>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Plasteel"]</xpath>
+    <value>
+      <li Class="RimForge.Extension">
+        <meltingPoint>1600</meltingPoint>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Uranium"]</xpath>
+    <value>
+      <li Class="RimForge.Extension">
+        <meltingPoint>1100</meltingPoint>
+      </li>
+    </value>
+  </Operation>
+
+</Patch>

--- a/About/About.xml
+++ b/About/About.xml
@@ -6,6 +6,7 @@
   <supportedVersions>
     <li>1.4</li>
     <li>1.5</li>
+    <li>1.6</li>
   </supportedVersions>
   <url>https://github.com/Epicguru/RimForge</url>
   <description>A mid-tech modpack that add new materials, weapons, turrets, power, utilities and more:

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -12,4 +12,10 @@
     <li IfModActive="vanillaexpanded.achievements">1.5/Achievements</li>
     <li IfModActive="CETeam.CombatExtended">1.5/CE_Patches</li>
   </v1.5>
+  <v1.6>
+    <li>/</li>
+    <li>1.6</li>
+    <li IfModActive="vanillaexpanded.achievements">1.6/Achievements</li>
+    <li IfModActive="CETeam.CombatExtended">1.6/CE_Patches</li>
+  </v1.6>
 </loadFolders>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
 	<PropertyGroup>
-		<RimworldVersion>1.5</RimworldVersion>
+		<RimworldVersion>1.6</RimworldVersion>
 	</PropertyGroup>
 
 </Project>

--- a/Source/RFAchievements/RFAchievements.csproj
+++ b/Source/RFAchievements/RFAchievements.csproj
@@ -14,13 +14,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="AchievementsExpanded" Version="1.4.82" />
-		<PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+		<PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
 		<ProjectReference Include="..\RimForge\RimForge.csproj">
 			<CopyLocal>false</CopyLocal>
 			<Private>false</Private>
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</ProjectReference>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4060-beta" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4494-beta" />
   </ItemGroup>    
   
 	<!-- Output -->

--- a/Source/RimForge/Buildings/Building_GreenhouseController.cs
+++ b/Source/RimForge/Buildings/Building_GreenhouseController.cs
@@ -4,6 +4,8 @@ using LudeonTK;
 using RimForge.Comps;
 using UnityEngine;
 using Verse;
+using System.Reflection;
+using Unity.Collections;
 
 namespace RimForge.Buildings
 {
@@ -50,6 +52,11 @@ namespace RimForge.Buildings
         private int cellRotation;
         private int tickCounter;
         private int tickCounter2;
+
+        static readonly FieldInfo _fiAccumulatedGlow =
+            typeof(GlowGrid).GetField("accumulatedGlow", BindingFlags.Instance | BindingFlags.NonPublic);
+        static readonly FieldInfo _fiAccumulatedGlowNoCavePlants =
+            typeof(GlowGrid).GetField("accumulatedGlowNoCavePlants", BindingFlags.Instance | BindingFlags.NonPublic);
 
         public virtual float GetSpecialPlantGrowthPerTick(Plant plant)
         {
@@ -110,8 +117,11 @@ namespace RimForge.Buildings
             {
                 int index = map.cellIndices.CellToIndex(cell);
 
-                map.glowGrid.cachedAccumulatedGlow[index] = light;
-                map.glowGrid.cachedAccumulatedGlowNoCavePlants[index] = light;
+                var gg = map.glowGrid;
+                var glowArr = (NativeArray<Color32>)_fiAccumulatedGlow.GetValue(gg);
+                glowArr[index] = light;
+                var glowNoCaveArr = (NativeArray<Color32>)_fiAccumulatedGlowNoCavePlants.GetValue(gg);
+                glowNoCaveArr[index] = light;
 
                 var list = map.thingGrid.ThingsListAtFast(index);
                 for(int i = 0; i < list.Count; i++)

--- a/Source/RimForge/Buildings/Building_RitualCore.cs
+++ b/Source/RimForge/Buildings/Building_RitualCore.cs
@@ -342,14 +342,18 @@ namespace RimForge.Buildings
                 Core.GenericAchievementEvent(Core.AchievementEvent.RitualPerformed);
 
                 // Give negative thoughts to all colonists.
+                IEnumerable<Pawn> mapPawns = this.Map.mapPawns.FreeColonistsAndPrisoners;
+                IEnumerable<Pawn> worldPawns = Find.WorldPawns.AllPawnsAlive;
+                Func<Pawn, bool> keep = p =>
+                p.IsColonistPlayerControlled
+                || p.IsPrisonerOfColony;
                 int thoughtLevel = SacrificePawn.guilt.IsGuilty ? 1 : 0;
-                foreach (var pawn in PawnsFinder.AllMapsCaravansAndTravelingTransportPods_Alive_FreeColonistsAndPrisoners)
-                {
-                    if (!pawn.IsColonist)
-                        continue;
-
+                var targets = mapPawns
+                    .Concat(worldPawns)
+                    .Where(keep)
+                    .Distinct();
+                foreach (var pawn in targets)
                     pawn.TryGiveThought(RFDefOf.RF_RitualBadThought, thoughtLevel);
-                }
 
                 // Kill the sacrifice.
                 TakeHeart(SacrificePawn);

--- a/Source/RimForge/Comps/CompWirelessPower.cs
+++ b/Source/RimForge/Comps/CompWirelessPower.cs
@@ -100,11 +100,11 @@ namespace RimForge.Comps
             this.currentPower = -Mathf.Abs(watts);
         }
 
-        public override void PostDeSpawn(Map map)
+        public override void PostDeSpawn(Map map, DestroyMode mode)
         {
             // Note: Not really necessary, since this lists in the channel are constantly sanitized.
             // However, it is good practice anyway.
-            base.PostDeSpawn(map);
+            base.PostDeSpawn(map, mode);
             Channel?.UnRegister(this);
         }
 

--- a/Source/RimForge/Effects/MapEffectHandler.cs
+++ b/Source/RimForge/Effects/MapEffectHandler.cs
@@ -69,9 +69,9 @@ namespace RimForge.Effects
             
         }
 
-        public override void FinalizeInit()
+        public override void FinalizeInit(bool fromLoad)
         {
-            base.FinalizeInit();
+            base.FinalizeInit(fromLoad);
             Patch_DynamicDrawManager_DrawDynamicThings.TryRegisterListener(OnDrawLate);
 
             if (ThreadedHandler.IsRunning)

--- a/Source/RimForge/Patches/Patch_QualityUtility_GenerateQualityCreatedByPawn.cs
+++ b/Source/RimForge/Patches/Patch_QualityUtility_GenerateQualityCreatedByPawn.cs
@@ -5,11 +5,13 @@ using Verse;
 
 namespace RimForge.Patches
 {
-    [HarmonyPatch(typeof(QualityUtility), "GenerateQualityCreatedByPawn", typeof(Pawn), typeof(SkillDef))]
+    [HarmonyPatch(typeof(QualityUtility), nameof(QualityUtility.GenerateQualityCreatedByPawn),
+        new[] { typeof(Pawn), typeof(SkillDef), typeof(bool) })]
     static class Patch_QualityUtility_GenerateQualityCreatedByPawn
     {
-        static void Postfix(Pawn pawn, SkillDef relevantSkill, ref QualityCategory __result)
+        static void Postfix(Pawn pawn, SkillDef relevantSkill, bool consumeInspiration, ref QualityCategory __result)
         {
+            
             if (__result == QualityCategory.Legendary)
                 return; // Can't improve.
 
@@ -49,10 +51,12 @@ namespace RimForge.Patches
             }
 
             if (pawn.IsColonist && didIncrease)
-            { 
-                Vector3 pos = pawn.DrawPos + new Vector3(0, 0, 1);
+            {
+                Vector3 pos = pawn.DrawPos;
                 pos.y = AltitudeLayer.MoteOverhead.AltitudeFor();
-                MoteMaker.ThrowText(pos, pawn.Map, "RF.Blessing.IncreasedMessage".Translate(__result.GetLabel()), Color.green);
+                MoteMaker.ThrowText(pos, pawn.Map,
+                    "RF.Blessing.IncreasedMessage".Translate(__result.GetLabel()),
+                    Color.green);
             }
 
             //Core.Log($"Running Blessing of Zir on {pawn.LabelCap}: increased quality to {__result} from {old}");

--- a/Source/RimForge/Patches/Patch_QualityUtility_GenerateQualityCreatedByPawn.cs
+++ b/Source/RimForge/Patches/Patch_QualityUtility_GenerateQualityCreatedByPawn.cs
@@ -52,7 +52,7 @@ namespace RimForge.Patches
 
             if (pawn.IsColonist && didIncrease)
             {
-                Vector3 pos = pawn.DrawPos;
+                Vector3 pos = pawn.DrawPos + new Vector3(0, 0, 1);
                 pos.y = AltitudeLayer.MoteOverhead.AltitudeFor();
                 MoteMaker.ThrowText(pos, pawn.Map,
                     "RF.Blessing.IncreasedMessage".Translate(__result.GetLabel()),

--- a/Source/RimForge/RimForge.csproj
+++ b/Source/RimForge/RimForge.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
+    <PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
     <PackageReference Include="Lib.InGameWiki" Version="15.0.1" />
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4060-beta" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4494-beta" />
     
     <!-- Ungodly hack to access rimworld private properties & methods -->
-    <PackageReference Include="Krafs.Publicizer" Version="2.2.1">
+    <PackageReference Include="Krafs.Publicizer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Source/RimForge/TraitTracker.cs
+++ b/Source/RimForge/TraitTracker.cs
@@ -95,9 +95,9 @@ namespace RimForge
             explosionEffects ??= new List<ExplosionEffect>();
         }
 
-        public override void FinalizeInit()
+        public override void FinalizeInit(bool fromLoad)
         {
-            base.FinalizeInit();
+            base.FinalizeInit(fromLoad);
             HEShellKillTracker.Init();
         }
 


### PR DESCRIPTION
This PR brings RimForge in line with the 1.6 API and fixes a handful of breaking changes:

- Dependencies
  - Bumped Krafs.Rimworld.Ref to 1.6.4493-beta
  - Upgraded Harmony to 2.3.6
- Method signature updates
  - CompWirelessPower.PostDeSpawn(Map, DestroyMode)
  - MapEffectHandler.FinalizeInit(bool fromLoad)
  - TraitTracker.FinalizeInit(bool fromLoad)
- GlowGrid field access
  - Replaced now-removed cachedAccumulatedGlow* with reflection into private accumulatedGlow / accumulatedGlowNoCavePlants arrays
- Pawn collection replacement
  - Replaced the removed PawnsFinder.AllMapsCaravansAndTravelingTransportPods_Alive_FreeColonistsAndPrisoners with a merged Map.mapPawns.FreeColonistsAndPrisoners + Find.WorldPawns.AllPawnsAlive filtered for player-controlled colonists & prisoners
- Harmony patch fix
  - Updated Patch_QualityUtility_GenerateQualityCreatedByPawn to match the new 1.6 signature (Pawn, SkillDef, bool)
  
All changes have been tested in-game.